### PR TITLE
Fix return value of output messages that escaping pipe (|) character

### DIFF
--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -393,7 +393,7 @@ class LogChecker:
             state_string = 'CRITICAL'
         if self.state != LogChecker.STATE_OK:
             message = "%s: %s" % (state_string, ', '.join(self.messages))
-        return message
+        return message.replace('|', '(pipe)')
 
     @classmethod
     def get_pattern_list(cls, pattern_string, pattern_filename):

--- a/test_check_log_ng.py
+++ b/test_check_log_ng.py
@@ -951,6 +951,38 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertFalse(os.path.exists(seekfile1_1))
         self.assertTrue(os.path.exists(seekfile1_2))
 
+    def test_replace_pipe_symbol(self):
+        """replace pipe symbol
+        """
+        initial_data = {
+            "logformat": self.logformat_syslog,
+            "pattern_list": ["ERROR"],
+            "critical_pattern_list": [],
+            "negpattern_list": [],
+            "critical_negpattern_list": [],
+            "case_insensitive": False,
+            "warning": 1,
+            "critical": 0,
+            "nodiff_warn": False,
+            "nodiff_crit": False,
+            "trace_inode": False,
+            "multiline": False,
+            "scantime": 86400,
+            "expiration": 691200
+        }
+        log = LogChecker(initial_data)
+
+        f = open(self.logfile, 'a')
+        f.write("Dec | 5 12:34:56 hostname noop: NOOP\n")
+        f.write("Dec | 5 12:34:56 hostname test: ERROR\n")
+        f.write("Dec | 5 12:34:57 hostname noop: NOOP\n")
+        f.flush()
+        f.close()
+
+        log.check_log(self.logfile, self.seekfile)
+
+        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
+        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec (pipe) 5 12:34:56 hostname test: ERROR at %s' % self.logfile)
 
 # class TestCommandLineParser(pikzie.TestCase):
 #


### PR DESCRIPTION
### Example

raw output

```
DISK OK - free space: / 3326 MB (56%); | /=2643MB;5948;5958;0;5968
```

before

```
DISK OK - free space: / 3326 MB (56%);
```

after

```

DISK OK - free space: / 3326 MB (56%); (pipe) /=2643MB;5948;5958;0;5968
```
