### PR TITLE
[WIP] Support the feature to cache the last result in a period of time.

### DIFF
--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -724,6 +724,19 @@ class LogChecker:
             pass
     load_cache = staticmethod(load_cache)
 
+    def create_cache(cache_file, message, state):
+        try:
+            tmp_file = ".".join([cache_file, str(os.getpid())])
+            f = open(tmp_file, mode="w")
+            f.write(pickle.dumps([message, state]))
+            f.close()
+            os.chmod(tmp_file, 0666)
+            os.rename(tmp_file, cache_file)
+        except:
+            _debug("Cannot create cache file %s" % (cache_file))
+            pass
+    create_cache = staticmethod(create_cache)
+
 
 def main():
     parser = LogChecker.make_parser()

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -7,6 +7,7 @@ import glob
 import time
 import re
 import base64
+import pickle
 from optparse import OptionParser
 
 # Globals
@@ -691,6 +692,19 @@ class LogChecker:
 
         return (options, args)
     check_parser_options = staticmethod(check_parser_options)
+
+    def serialize_optargs(options, args):
+        serialized = []
+        _options = eval(str(options))
+        for key in sorted(_options.keys()):
+            serialized.append(str(key))
+            serialized.append(str(_options.get(key)))
+        serialized.extend(args)
+        dumped = pickle.dumps(serialized)
+
+        return LogChecker.get_digest(dumped)
+
+    serialize_optargs = staticmethod(serialize_optargs)
 
 
 def main():

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -711,6 +711,19 @@ class LogChecker:
         return (last_updated_time + cache_time) < now
     is_expired = staticmethod(is_expired)
 
+    def load_cache(cache_file, cache_time):
+        try:
+            if os.path.exists(cache_file) and not LogChecker.is_expired(cache_file, cache_time):
+                _debug("Enable cache")
+                f = open(cache_file, "r")
+                prev_result = pickle.load(f)
+                f.close()
+                return prev_result
+        except:
+            _debug("Cannot load cache file %s" % (cache_file))
+            pass
+    load_cache = staticmethod(load_cache)
+
 
 def main():
     parser = LogChecker.make_parser()

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -703,8 +703,13 @@ class LogChecker:
         dumped = pickle.dumps(serialized)
 
         return LogChecker.get_digest(dumped)
-
     serialize_optargs = staticmethod(serialize_optargs)
+
+    def is_expired(cache_file, cache_time):
+        now = time.time()
+        last_updated_time = os.stat(cache_file).st_mtime
+        return (last_updated_time + cache_time) < now
+    is_expired = staticmethod(is_expired)
 
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+argparse==1.4.0
+filelock==2.0.6


### PR DESCRIPTION
The maximum check attempts value for the service should always be 1, to prevent Nagios from retrying the service check (the next time the check is run it will not produce the same results). 
This is frequently cause a time-out error. By using the cache, the above problem is solved because you can specify a value greater than 1.

---

Example (caching a result while 10 seconds.)
- first run

```
$ python check_log_ng.py -l 'sample_log*' -S tmp/ -p 'a' --critical-pattern 'test_pattern' -C 10 --debug
DEBUG: logfile='sample_log1', seekfile='tmp/sample_log1.seek'
DEBUG: Skipped: filesize == offset
OK - No matches found.
```
- next run within 10 seconds

```
$ python check_log_ng.py -l 'sample_log*' -S tmp/ -p 'a' --critical-pattern 'b' -C 10 --debug
DEBUG: Enable cache
OK - No matches found.
```
