### PR TITLE
add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "2.6"
   - "2.7"
 install:
-  - [[ -f requirements.txt ]] && pip install -r requirements.txt
+  - "[[ -f requirements.txt ]] && pip install -r requirements.txt"
 script:
   - PYTHONPATH=. python -m unittest test_check_log_ng

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
-install:
-  - test -f requirements.txt && pip install -r requirements.txt
+#install:
+#  - pip install -r requirements.txt
 script:
   - PYTHONPATH=. python -m unittest test_check_log_ng

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "2.6"
   - "2.7"
 install:
-  - "[[ -f requirements.txt ]] && pip install -r requirements.txt"
+  - bash -c "[[ -f requirements.txt ]] && pip install -r requirements.txt"
 script:
   - PYTHONPATH=. python -m unittest test_check_log_ng

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "2.6"
   - "2.7"
 install:
-  - pip install -r requirements.txt
+  - [[ -f requirements.txt ]] && pip install -r requirements.txt
 script:
   - PYTHONPATH=. python -m unittest test_check_log_ng

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "2.6"
   - "2.7"
 install:
-  - bash -c "[[ -f requirements.txt ]] && pip install -r requirements.txt"
+  - test -f requirements.txt && pip install -r requirements.txt
 script:
   - PYTHONPATH=. python -m unittest test_check_log_ng

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.3"
+  - "2.4"
+  - "2.5"
+  - "2.6"
+  - "2.7"
+install:
+  - pip install -r requirements.txt
+script:
+  - PYTHONPATH=. python -m unittest test_check_log_ng

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 python:
-  - "2.3"
-  - "2.4"
-  - "2.5"
   - "2.6"
   - "2.7"
 install:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # check_log_ng
 
+![Build Status](https://travis-ci.org/heartbeatsjp/check_log_ng.svg?branch=master)
+
 Log file regular expression based parser plugin for Nagios.
 
 ## Installation
@@ -136,5 +138,4 @@ If you have a problem, please [create an issue](https://github.com/heartbeatsjp/
 - caching result for a period of time
 - handling character encodings
 - support python 3
-- run tests in [walter](https://github.com/walter-cd/walter) automatically
 - improve the current test code coverage


### PR DESCRIPTION
travis-ci no longer support python 2.5-, so only test in python 2.6+
https://docs.travis-ci.com/user/languages/python/#Choosing-Python-versions-to-test-against