### PR TITLE
Add the feature for caching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Log file regular expression based parser plugin for Nagios.
 
 ## Installation
 
-Clone a copy of the main check_log_ng git repo and add execute permission.
+Clone a copy of the main `check_log_ng` git repo and add execute permission.
 
 ```
 $ git@github.com:heartbeatsjp/check_log_ng.git
@@ -16,17 +16,17 @@ $ chmod 755 check_log_ng.py
 Copy this plugin to nagios-plugins directory.
 
 ```
-$ cp ./check_log_ng.py /usr/lib64/nagios/plugins/
+$ cp check_log_ng.py /usr/lib64/nagios/plugins/
 ```
 
-Create a directory for saving a seek files and change the owner of the directory.
-
+Create a directory to save a cache file, a lock file and seek files.
+Change the owner of the directory.
 ```
 $ mkdir /var/spool/check_log_ng
 $ chown nrpe:nrpe /var/spool/check_log_ng
 ```
 
-If root privileges is necessary for reading of the logfile, edit the sudoers file.
+If root privilege is necessary to read log files, edit a  sudoers file.
 
 ```
 Defaults:nrpe !requiretty
@@ -120,6 +120,9 @@ Options:
                         option --cachetime.
   --cachetime=<seconds>
                         The period to cache the result. Default is 60.
+  --lock-timeout=<seconds>
+                        If another proccess is running, wait for the period of
+                        this lock timeout. Default is 3.
   --debug               Enable debug.
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Options:
                         Remove expired seek files. See also --expiration.
   -M, --multiline       Consider multiple lines with same key as one log
                         output. See also --multiline.
+  --cache               Cache the result for the period specified by the
+                        option --cachetime.
+  --cachetime=<seconds>
+                        The period to cache the result. Default is 60.
   --debug               Enable debug.
 ```
 
@@ -135,7 +139,6 @@ If you have a problem, please [create an issue](https://github.com/heartbeatsjp/
 
 ## Todo
 
-- caching result for a period of time
 - handling character encodings
 - support python 3
 - improve the current test code coverage

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -579,7 +579,7 @@ class LogChecker:
         try:
             fcntl.flock(lockfileobj, fcntl.LOCK_EX|fcntl.LOCK_NB)
         except IOError:
-            time.sleep(RETRY_PERIOD)
+            time.sleep(LogChecker.RETRY_PERIOD)
             return None
         lockfileobj.flush()
         return lockfileobj


### PR DESCRIPTION
This pull request adds the following feature for caching.

- You can specify whether to enable the cache function with the option `--cache`. Default False (for backwards compatibility).
- You can specify the lifetime of the cache with the option `--cachetime`. Default 60 seconds.
- When the cache function is invalid, the same processing as before is performed.
- If the cache file does not exist or the cache has expired, the analysis processing is executed and the cache is updated.
- If the cache exists and does not expired, the result is returned from the cache.
- Analysis processing and caache update is done as transaction.
- If another process is executing a transaction, if it is within the number of seconds of lock timeout, it returns to checking the cache every 0.5 second. If timeout seconds have elapsed, it returns `UNKNOWN` as the status.
