### PR TITLE
Add python3 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.5"
+  - "3.6"
 #install:
 #  - pip install -r requirements.txt
 script:

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2014 Takamura Narimichi and Takizawa Takashi All rights reserved.
+Copyright (C) 2014-2018 Takamura Narimichi and Takizawa Takashi All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 ![Build Status](https://travis-ci.org/heartbeatsjp/check_log_ng.svg?branch=master)
 
-Log file regular expression based parser plugin for Nagios.
+A log file regular expression-based parser plugin for Nagios.
+
+## Requirement
+
+- Python 2.6, 2.7, 3.5 or 3.6.
+- On python 2.6, argparse module.
 
 ## Installation
 
@@ -22,8 +27,8 @@ $ cp check_log_ng.py /usr/lib64/nagios/plugins/
 Create a directory to save a cache file, a lock file and seek files.
 Change the owner of the directory.
 ```
-$ mkdir /var/spool/check_log_ng
-$ chown nrpe:nrpe /var/spool/check_log_ng
+$ sudo mkdir /var/spool/check_log_ng
+$ sudo chown nrpe:nrpe /var/spool/check_log_ng
 ```
 
 If root privilege is necessary to read log files, edit a  sudoers file.
@@ -31,6 +36,13 @@ If root privilege is necessary to read log files, edit a  sudoers file.
 ```
 Defaults:nrpe !requiretty
 nagios ALL=(root) NOPASSWD: /usr/lib64/nagios/plugins/check_log_ng.py
+```
+
+If you run on python 2.6, install argparse module.
+If you use RHEL6/CentOS6, you can run:
+
+```
+$ sudo yum install python-argparse
 ```
 
 ## Documentation
@@ -42,96 +54,94 @@ https://github.com/heartbeatsjp/check_log_ng/wiki
 ## Usage
 
 ```
-Options:
-  --version             show program's version number and exit
+usage: check_log_ng.py [option ...]
+
+A log file regular expression-based parser plugin for Nagios.
+
+optional arguments:
   -h, --help            show this help message and exit
-  -l <filename>, --logfile=<filename>
+  --version             show program's version number and exit
+  -l <filename>, --logfile <filename>
                         The pattern of log files to be scanned. The
                         metacharacter * and ? are allowed. If you want to set
                         multiple patterns, set a space between patterns.
-  -F <format>, --format=<format>
+  -F <format>, --format <format>
                         The regular expression of format of log to parse.
                         Required two group, format of '^(TIMESTAMP and
                         TAG)(.*)$'. Also, may use %%, %Y, %y, %a, %b, %m, %d,
-                        %e, %H, %M, %S, %F and %T of strftime(3). Default: the
-                        regular expression for syslog.
-  -s <filename>, --seekfile=<filename>
+                        %e, %H, %M, %S, %F and %T of strftime(3). (default:
+                        the regular expression for syslog.
+  -s <filename>, --seekfile <filename>
                         The temporary file to store the seek position of the
                         last scan. If check multiple log files, ignore this
                         option. Use -S seekfile_directory.
-  -S <seekfile_directory>, --seekfile-directory=<seekfile_directory>
+  -S <seekfile_directory>, --seekfile-directory <seekfile_directory>
                         The directory of the temporary file to store the seek
                         position of the last scan. If check multiple log
                         files, require this option.
-  -T <seekfile_tag>, --seekfile-tag=<seekfile_tag>
+  -T <seekfile_tag>, --seekfile-tag <seekfile_tag>
                         Add a tag in the seek files names, to prevent names
                         collisions. Useful to avoid maintaining many '-S'
                         temporary directories when you check the same files
-                        several times with different options.
+                        several times with different args.
   -I, --trace-inode     Trace the inode of log files. If set, use inode
                         information as a seek file.
-  -p <pattern>, --pattern=<pattern>
+  -p <pattern>, --pattern <pattern>
                         The regular expression to scan for in the log file.
-  -P <filename>, --patternfile=<filename>
+  -P <filename>, --patternfile <filename>
                         File containing regular expressions, one per line.
-  --critical-pattern=<pattern>
+  --critical-pattern <pattern>
                         The regular expression to scan for in the log file. In
                         spite of --critical option, return CRITICAL.
-  --critical-patternfile=<filename>
+  --critical-patternfile <filename>
                         File containing regular expressions, one per line. In
                         spite of --critical option, return CRITICAL.
-  -n <pattern>, --negpattern=<pattern>
+  -n <pattern>, --negpattern <pattern>
                         The regular expression to skip except as critical
                         pattern in the log file.
-  -N <filename>, -f <filename>, --negpatternfile=<filename>
-                        Specifies a file with regular expressions which all
-                        will be skipped except as critical pattern, one per
-                        line.
-  --critical-negpattern=<pattern>
-                        The regular expression to skip in the log file
-  --critical-negpatternfile=<filename>
-                        Specifies a file with regular expressions which all
+  -N <filename>, -f <filename>, --negpatternfile <filename>
+                        Specify a file with regular expressions which all will
+                        be skipped except as critical pattern, one per line.
+  --critical-negpattern <pattern>
+                        The regular expression to skip in the log file.
+  --critical-negpatternfile <filename>
+                        Specifiy a file with regular expressions which all
                         will be skipped, one per line.
   -i, --case-insensitive
-                        Do a case insensitive scan
-  --encoding=<encoding>
-                        Specify the character encoding in the log file. If not
-                        specified, it is treated as it is.
-  -w <number>, --warning=<number>
+                        Do a case insensitive scan.
+  --encoding <encoding>
+                        Specify the character encoding in the log file.
+                        (default: utf-8)
+  -w <number>, --warning <number>
                         Return WARNING if at least this many matches found.
-                        The default is 1.
-  -c <number>, --critical=<number>
+                        (default: 1)
+  -c <number>, --critical <number>
                         Return CRITICAL if at least this many matches found.
-                        The default is 0, i.e. don't return critical alerts
-                        unless specified explicitly.
+                        i.e. don't return critical alerts unless specified
+                        explicitly. (default: 0)
   -d, --nodiff-warn     Return WARNING if the log file was not written to
                         since the last scan. (not implemented)
   -D, --nodiff-crit     Return CRITICAL if the log was not written to since
                         the last scan. (not impremented)
-  -t <seconds>, --scantime=<seconds>
+  -t <seconds>, --scantime <seconds>
                         The range of time to scan. The log files older than
-                        this time are not scanned. Default is 86400.
-  -E <seconds>, --expiration=<seconds>
-                        The expiration of seek files. Default is 691200. This
-                        value must be greater than period of log rotation when
-                        use with -R option.
+                        this time are not scanned. (default: 86400)
+  -E <seconds>, --expiration <seconds>
+                        The expiration of seek files. This value must be
+                        greater than period of log rotation when use with -R
+                        option. (default: 691200)
   -R, --remove-seekfile
                         Remove expired seek files. See also --expiration.
   -M, --multiline       Consider multiple lines with same key as one log
                         output. See also --multiline.
   --cache               Cache the result for the period specified by the
                         option --cachetime.
-  --cachetime=<seconds>
-                        The period to cache the result. Default is 60.
-  --lock-timeout=<seconds>
+  --cachetime <seconds>
+                        The period to cache the result. (default: 60)
+  --lock-timeout <seconds>
                         If another proccess is running, wait for the period of
-                        this lock timeout. Default is 3.
-  --debug               Enable debug.
+                        this lock timeout. (default: 3)
 ```
-
-### Note
-
-The --encoding option is supported in Python 2.6 or higher.
 
 ## Contributing
 
@@ -143,11 +153,16 @@ If you have a problem, please [create an issue](https://github.com/heartbeatsjp/
 1. Push to the branch (git push origin my-new-feature)
 1. Create new Pull Request
 
+If you debug this script, use -O option.
+
+```
+python -O check_log_ng.py ...
+```
+
 ## License
 
 [BSD](https://github.com/heartbeatsjp/check_log_ng/blob/master/LICENSE.txt)
 
 ## Todo
 
-- support python 3
 - improve the current test code coverage

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -1,25 +1,27 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Python 2.4 - 2.7
-"""Log file regular expression based parser plugin for Nagios."""
+# Python 2.6, 2.7, 3.5, 3.6
+# Require argparse module on python 2.6.
+"""A log file regular expression-based parser plugin for Nagios."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import sys
 import os
+import io
 import glob
 import time
 import re
+import hashlib
 import base64
 import fcntl
-from optparse import OptionParser
+import warnings
+import argparse
 
 # Globals
-CHECK_LOG_NG_VERSION = '1.0.8'
-debug = False
-
-
-def _debug(string):
-    if debug:
-        print "DEBUG: %s" % string
+CHECK_LOG_NG_VERSION = '2.0.0'
 
 
 class LogChecker(object):
@@ -50,7 +52,7 @@ class LogChecker(object):
         self.negpattern_list = []
         self.critical_negpattern_list = []
         self.case_insensitive = False
-        self.encoding = None
+        self.encoding = 'utf-8'
         self.warning = 1
         self.critical = 0
         self.nodiff_warn = False
@@ -71,7 +73,8 @@ class LogChecker(object):
         if self.case_insensitive:
             self.pattern_flags = re.IGNORECASE
 
-        self.re_logformat = re.compile(LogChecker.expand_logformat_by_strftime(self.logformat))
+        self.re_logformat = re.compile(LogChecker.expand_logformat_by_strftime(
+            LogChecker.to_unicode(self.logformat)))
 
         # status variables
         self.state = None
@@ -97,67 +100,29 @@ class LogChecker(object):
 
         return True
 
-    def _check_negpattern(self, line):
-        """Check whether the line matches negative pattern.
-
-           If matched, return True.
-        """
-        if not self.negpattern_list:
-            return False
-        for negpattern in self.negpattern_list:
-            if negpattern is None or negpattern == '':
-                continue
-            matchobj = re.search(negpattern, line, self.pattern_flags)
-            if matchobj is not None:
-                _debug("Skip cause '%s'" % (negpattern))
-                return True
-        return False
-
-    def _check_critical_negpattern(self, line):
-        """Check whether the line matches critical negative pattern.
-
-           If matched, return True.
-        """
-        if not self.critical_negpattern_list:
-            return False
-        for critical_negpattern in self.critical_negpattern_list:
-            if critical_negpattern is None or critical_negpattern == '':
-                continue
-            matchobj = re.search(critical_negpattern, line, self.pattern_flags)
-            if matchobj is not None:
-                _debug("Skip cause '%s'" % (critical_negpattern))
-                return True
-        return False
-
-    def _find_pattern(self, line):
+    def _find_pattern(self, pattern_list, message, negative=False, critical=False):
         """Find pattern.
 
            If found, return True.
         """
-        if not self.pattern_list:
+        if not pattern_list:
             return False
-        for pattern in self.pattern_list:
-            if pattern is None or pattern == '':
+        for pattern in pattern_list:
+            if not pattern:
                 continue
-            matchobj = re.search(pattern, line, self.pattern_flags)
-            if matchobj is not None:
-                _debug("'%s' found" % (pattern))
-                return True
-        return False
-
-    def _find_critical_pattern(self, line):
-        """Find critical pattern.
-
-           If found, return True.
-        """
-        if not self.critical_pattern_list:
-            return False
-        for pattern in self.critical_pattern_list:
-            if pattern is None or pattern == '':
-                continue
-            matchobj = re.search(pattern, line, self.pattern_flags)
-            if matchobj is not None:
-                _debug("'%s' found as CRITICAL" % (pattern))
+            pattern = LogChecker.to_unicode(pattern)
+            matchobj = re.search(pattern, message, self.pattern_flags)
+            if matchobj:
+                if negative:
+                    if critical:
+                        _debug("critical_negpattern: '{0}' found".format(pattern))
+                    else:
+                        _debug("negpattern: '{0}' found".format(pattern))
+                else:
+                    if critical:
+                        _debug("critical_pattern: '{0}' found".format(pattern))
+                    else:
+                        _debug("pattern: '{0}' found".format(pattern))
                 return True
         return False
 
@@ -167,14 +132,15 @@ class LogChecker(object):
         try:
             os.chdir(seekfile_directory)
         except OSError:
-            print "Unable to chdir seekfile_directory: %s" % (seekfile_directory)
+            print("Unable to chdir seekfile_directory: {0}".format(seekfile_directory))
             sys.exit(LogChecker.STATE_UNKNOWN)
 
         curtime = time.time()
         for logfile_pattern in logfile_pattern_list.split():
             if logfile_pattern is None or logfile_pattern == '':
                 continue
-            seekfile_pattern = re.sub(r'[^-0-9A-Za-z*?]', '_', logfile_pattern) + seekfile_tag + LogChecker.SUFFIX_SEEK
+            seekfile_pattern = re.sub(r'[^-0-9A-Za-z*?]', '_', logfile_pattern) \
+                + seekfile_tag + LogChecker.SUFFIX_SEEK
             for seekfile in glob.glob(seekfile_pattern):
 
                 if not os.path.isfile(seekfile):
@@ -182,16 +148,16 @@ class LogChecker(object):
                 if curtime - self.expiration <= os.stat(seekfile).st_mtime:
                     continue
                 try:
-                    _debug("remove seekfile: %s" % seekfile)
+                    _debug("remove seekfile: {0}".format(seekfile))
                     os.unlink(seekfile)
                 except OSError:
-                    print "Unable to remove old seekfile: %s" % (seekfile)
+                    print("Unable to remove old seekfile: {0}".format(seekfile))
                     sys.exit(LogChecker.STATE_UNKNOWN)
 
         try:
             os.chdir(cwd)
         except OSError:
-            print "Unable to chdir: %s" % (cwd)
+            print("Unable to chdir: {0}".format(cwd))
             sys.exit(LogChecker.STATE_UNKNOWN)
 
         return True
@@ -206,7 +172,7 @@ class LogChecker(object):
         try:
             os.chdir(seekfile_directory)
         except OSError:
-            print "Unable to chdir seekfile_directory: %s" % (seekfile_directory)
+            print("Unable to chdir seekfile_directory: {0}".format(seekfile_directory))
             sys.exit(LogChecker.STATE_UNKNOWN)
 
         curtime = time.time()
@@ -217,16 +183,16 @@ class LogChecker(object):
             if curtime - self.expiration <= os.stat(seekfile).st_mtime:
                 continue
             try:
-                _debug("remove seekfile: %s" % seekfile)
+                _debug("remove seekfile: {0}".format(seekfile))
                 os.unlink(seekfile)
             except OSError:
-                print "Unable to remove old seekfile: %s" % (seekfile)
+                print("Unable to remove old seekfile: {0}".format(seekfile))
                 sys.exit(LogChecker.STATE_UNKNOWN)
 
         try:
             os.chdir(cwd)
         except OSError:
-            print "Unable to chdir: %s" % (cwd)
+            print("Unable to chdir: {0}".format(cwd))
             sys.exit(LogChecker.STATE_UNKNOWN)
 
         return True
@@ -247,12 +213,12 @@ class LogChecker(object):
         num_critical = len(self.critical_found)
         if num_critical > 0:
             self.state = LogChecker.STATE_CRITICAL
-            self.messages.append("Critical Found %s lines: %s" %
-                                 (num_critical, ','.join(self.critical_found_messages)))
+            self.messages.append("Critical Found {0} lines: {1}" \
+                .format(num_critical, ','.join(self.critical_found_messages)))
         num = len(self.found)
         if num > 0:
-            self.messages.append("Found %s lines (limit=%s/%s): %s" %
-                                 (num, self.warning, self.critical, ','.join(self.found_messages)))
+            self.messages.append("Found {0} lines (limit={1}/{2}): {3}" \
+                .format(num, self.warning, self.critical, ','.join(self.found_messages)))
             if self.critical > 0 and self.critical <= num:
                 if self.state is None:
                     self.state = LogChecker.STATE_CRITICAL
@@ -265,13 +231,16 @@ class LogChecker(object):
 
     def _set_found(self, message, found, critical_found):
         """Set the found and critical_found if matching pattern is found."""
-        if self.encoding:
-            message = message.decode(self.encoding, errors='replace').encode('utf-8')
-        if (not self._check_negpattern(message)) and (not self._check_critical_negpattern(message)):
-            if self._find_pattern(message):
+        found_negpattern = self._find_pattern(
+            self.negpattern_list, message, negative=True)
+        found_critical_negpattern = self._find_pattern(
+            self.critical_negpattern_list, message, negative=True, critical=True)
+
+        if not found_negpattern and not found_critical_negpattern:
+            if self._find_pattern(self.pattern_list, message):
                 found.append(message)
-        if not self._check_critical_negpattern(message):
-            if self._find_critical_pattern(message):
+        if not found_critical_negpattern:
+            if self._find_pattern(self.critical_pattern_list, message, critical=True):
                 critical_found.append(message)
         return
 
@@ -283,12 +252,12 @@ class LogChecker(object):
         message = None
         cur_message = None
 
-        fileobj = open(logfile, 'r')
+        fileobj = io.open(logfile, mode='r', encoding=self.encoding, errors='replace')
         fileobj.seek(start_position, 0)
 
         for line in fileobj:
             line = line.rstrip()
-            _debug("line='%s'" % line)
+            _debug("line='{0}'".format(line))
 
             matchobj = self.re_logformat.match(line)
             # set cur_key and cur_message.
@@ -306,7 +275,7 @@ class LogChecker(object):
                 line_buffer.append(cur_message)
             else:
                 message = ' '.join(line_buffer)
-                _debug("message='%s'" % message)
+                _debug("message='{0}'".format(message))
                 self._set_found(message, found, critical_found)
 
                 # initialize variables for next loop
@@ -319,18 +288,18 @@ class LogChecker(object):
         # flush line buffer
         if line_buffer:
             message = ' '.join(line_buffer)
-            _debug("message='%s'" % message)
+            _debug("message='{0}'".format(message))
             self._set_found(message, found, critical_found)
         return end_position
 
     def _check_each_single_line(self, logfile, start_position, found, critical_found):
         """Match the pattern each a single line in the log file."""
-        fileobj = open(logfile, 'r')
+        fileobj = io.open(logfile, mode='r', encoding=self.encoding, errors='replace')
         fileobj.seek(start_position, 0)
 
         for line in fileobj:
             message = line.rstrip()
-            _debug("message='%s'" % message)
+            _debug("message='{0}'".format(message))
             self._set_found(message, found, critical_found)
         end_position = fileobj.tell()
         fileobj.close()
@@ -356,7 +325,9 @@ class LogChecker(object):
                     self.state = state
                     self.message = message
                     return
-            lockfileobj = LogChecker.lock(lockfile)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                lockfileobj = LogChecker.lock(lockfile)
             if lockfileobj:
                 locked = True
                 break
@@ -390,7 +361,7 @@ class LogChecker(object):
 
     def check_log(self, logfile, seekfile):
         """Check the log file."""
-        _debug("logfile='%s', seekfile='%s'" % (logfile, seekfile))
+        _debug("logfile='{0}', seekfile='{1}'".format(logfile, seekfile))
         if not os.path.exists(logfile):
             return
 
@@ -416,10 +387,12 @@ class LogChecker(object):
 
         if found:
             self.found.extend(found)
-            self.found_messages.append("%s at %s" % (','.join(found), logfile))
+            self.found_messages.append("{0} at {1}" \
+                .format(','.join(found), LogChecker.to_unicode(logfile)))
         if critical_found:
             self.critical_found.extend(critical_found)
-            self.critical_found_messages.append("%s at %s" % (','.join(critical_found), logfile))
+            self.critical_found_messages.append("{0} at {1}" \
+                .format(','.join(critical_found), LogChecker.to_unicode(logfile)))
 
         LogChecker.update_seekfile(seekfile, end_position)
         return
@@ -474,7 +447,7 @@ class LogChecker(object):
             elif self.state == LogChecker.STATE_CRITICAL:
                 state_string = 'CRITICAL'
             if self.state != LogChecker.STATE_OK:
-                message = "%s: %s" % (state_string, ', '.join(self.messages))
+                message = "{0}: {1}".format(state_string, ', '.join(self.messages))
             self.message = message.replace('|', '(pipe)')
         return self.message
 
@@ -485,7 +458,7 @@ class LogChecker(object):
         if os.stat(cachefile).st_mtime < time.time() - self.cachetime:
             _debug("Cache is expired: mtime < curtime - cachetime")
             return LogChecker.STATE_NO_CACHE, None
-        fileobj = open(cachefile)
+        fileobj = io.open(cachefile, mode='r', encoding='utf-8')
         line = fileobj.readline()
         fileobj.close()
         state, message = line.split("\t", 1)
@@ -494,8 +467,8 @@ class LogChecker(object):
     def update_cache(self, cachefile):
         """Update the cache."""
         tmp_cachefile = cachefile + "." + str(os.getpid())
-        cachefileobj = open(tmp_cachefile, 'w')
-        cachefileobj.write(str(self.get_state()))
+        cachefileobj = io.open(tmp_cachefile, mode='w', encoding='utf-8')
+        cachefileobj.write(LogChecker.to_unicode(str(self.get_state())))
         cachefileobj.write("\t")
         cachefileobj.write(self.get_message())
         cachefileobj.flush()
@@ -503,24 +476,26 @@ class LogChecker(object):
         os.rename(tmp_cachefile, cachefile)
         return True
 
+    @staticmethod
     def get_pattern_list(pattern_string, pattern_filename):
         """Get the pattern list."""
         pattern_list = []
         if pattern_string:
-            pattern_list.append(pattern_string)
+            pattern_list.append(LogChecker.to_unicode(pattern_string))
         if pattern_filename:
             if os.path.isfile(pattern_filename):
                 lines = []
-                fileobj = open(pattern_filename, 'r')
+                fileobj = io.open(pattern_filename, mode='r', encoding='utf-8')
                 for line in fileobj:
-                    line = line.rstrip()
-                    lines.append(line)
+                    pattern = line.rstrip()
+                    if pattern:
+                        lines.append(pattern)
                 fileobj.close()
                 if lines:
                     pattern_list.extend(lines)
         return pattern_list
-    get_pattern_list = staticmethod(get_pattern_list)
 
+    @staticmethod
     def expand_logformat_by_strftime(logformat):
         """Expand log format by strftime variables."""
         logformat = logformat.replace('%%', '_PERCENT_') \
@@ -538,45 +513,47 @@ class LogChecker(object):
             .replace('%S', '(?:[0-5][0-9]|60)') \
             .replace('_PERCENT_', '%')
         return logformat
-    expand_logformat_by_strftime = staticmethod(expand_logformat_by_strftime)
 
+    @staticmethod
     def get_seekfile(logfile_pattern, seekfile_directory,
                      logfile, trace_inode=False, seekfile_tag=''):
         """make filename of seekfile from logfile and get the filename."""
         prefix = None
         filename = None
         if trace_inode:
-            filename = str(os.stat(logfile).st_ino) + seekfile_tag + LogChecker.SUFFIX_SEEK_WITH_INODE
+            filename = str(os.stat(logfile).st_ino) + seekfile_tag \
+                + LogChecker.SUFFIX_SEEK_WITH_INODE
             prefix = LogChecker.get_digest(logfile_pattern)
         else:
-            filename = re.sub(r'[^-0-9A-Za-z]', '_', logfile) + seekfile_tag + LogChecker.SUFFIX_SEEK
+            filename = re.sub(r'[^-0-9A-Za-z]', '_', logfile) + seekfile_tag \
+                + LogChecker.SUFFIX_SEEK
         if prefix is not None:
             filename = prefix + '.' + filename
         seekfile = os.path.join(seekfile_directory, filename)
         return seekfile
-    get_seekfile = staticmethod(get_seekfile)
 
+    @staticmethod
     def update_seekfile(seekfile, position):
         """Update the seek file for the log file."""
         tmp_seekfile = seekfile + "." + str(os.getpid())
-        fileobj = open(tmp_seekfile, 'w')
-        fileobj.write(str(position))
+        fileobj = io.open(tmp_seekfile, mode='w', encoding='utf-8')
+        fileobj.write(LogChecker.to_unicode(str(position)))
         fileobj.flush()
         fileobj.close()
         os.rename(tmp_seekfile, seekfile)
         return True
-    update_seekfile = staticmethod(update_seekfile)
 
+    @staticmethod
     def read_seekfile(seekfile):
         """Read the offset of the log file from its seek file."""
         if not os.path.exists(seekfile):
             return 0
-        fileobj = open(seekfile)
+        fileobj = io.open(seekfile, mode='r', encoding='utf-8')
         offset = int(fileobj.readline())
         fileobj.close()
         return offset
-    read_seekfile = staticmethod(read_seekfile)
 
+    @staticmethod
     def get_prefix_datafile(seekfile, seekfile_directory, seekfile_tag=''):
         """Make the prefix of the file name for data files."""
         directory = None
@@ -592,19 +569,19 @@ class LogChecker(object):
         filename = "".join(filename_elements)
         prefix_datafile = os.path.join(directory, filename)
         return prefix_datafile
-    get_prefix_datafile = staticmethod(get_prefix_datafile)
 
+    @staticmethod
     def lock(lockfile):
         """Lock."""
-        lockfileobj = open(lockfile, 'w')
+        lockfileobj = io.open(lockfile, mode='w')
         try:
             fcntl.flock(lockfileobj, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except IOError:
             return None
         lockfileobj.flush()
         return lockfileobj
-    lock = staticmethod(lock)
 
+    @staticmethod
     def unlock(lockfile, lockfileobj):
         """Unlock."""
         if lockfileobj is None:
@@ -612,290 +589,333 @@ class LogChecker(object):
         lockfileobj.close()
         os.unlink(lockfile)
         return True
-    unlock = staticmethod(unlock)
 
+    @staticmethod
     def get_digest(string):
         """Get digest string."""
-        hashobj = None
-        try:
-            # for Python 2.5-2.7
-            import hashlib
-            hashobj = hashlib.sha1()
-        except ImportError:
-            try:
-                # for Python 2.4
-                import sha
-                hashobj = sha.new()
-            except ImportError:
-                pass
-
-        digest = None
-        if hashobj is not None:
-            hashobj.update(string)
-            digest = base64.urlsafe_b64encode(hashobj.digest())
-        else:
-            digest = base64.urlsafe_b64encode(string)
+        hashobj = hashlib.sha1()
+        hashobj.update(string.encode('utf-8'))
+        digest = base64.urlsafe_b64encode(hashobj.digest()).decode('utf-8')
         return digest
-    get_digest = staticmethod(get_digest)
 
+    @staticmethod
     def is_multiple_logfiles(logfile_pattern):
         """If the string of the log file pattern is multiple log files, return True."""
         matchobj = re.search('[*? ]', logfile_pattern)
         if matchobj is not None:
             return True
         return False
-    is_multiple_logfiles = staticmethod(is_multiple_logfiles)
 
+    @staticmethod
+    def to_unicode(string):
+        """Convert str to unicode"""
+        if sys.version_info >= (3,):
+            if isinstance(string, bytes):
+                return string.decode('utf-8')
+        else:
+            if isinstance(string, str):
+                return string.decode('utf-8')
+        return string
+
+def _debug(string):
+    if not __debug__:
+        print("DEBUG: {0}".format(string))
 
 def _make_parser():
-    usage = "Usage: %prog [option ...]"
-    version = "%%prog %s" % (CHECK_LOG_NG_VERSION)
-    parser = OptionParser(usage=usage, version=version)
-
-    parser.add_option("-l", "--logfile",
-                      action="store",
-                      dest="logfile_pattern",
-                      metavar="<filename>",
-                      help="The pattern of log files to be scanned. The metacharacter * and ? are allowed. If you want to set multiple patterns, set a space between patterns.")
-    parser.add_option("-F", "--format",
-                      action="store",
-                      dest="logformat",
-                      metavar="<format>",
-                      default=LogChecker.FORMAT_SYSLOG,
-                      help="The regular expression of format of log to parse. Required two group, format of '^(TIMESTAMP and TAG)(.*)$'. Also, may use %%, %Y, %y, %a, %b, %m, %d, %e, %H, %M, %S, %F and %T of strftime(3). Default: the regular expression for syslog.")
-    parser.add_option("-s", "--seekfile",
-                      action="store",
-                      dest="seekfile",
-                      metavar="<filename>",
-                      help="The temporary file to store the seek position of the last scan. If check multiple log files, ignore this option. Use -S seekfile_directory.")
-    parser.add_option("-S", "--seekfile-directory",
-                      action="store",
-                      dest="seekfile_directory",
-                      metavar="<seekfile_directory>",
-                      help="The directory of the temporary file to store the seek position of the last scan. If check multiple log files, require this option.")
-    parser.add_option("-T", "--seekfile-tag",
-                      action="store",
-                      dest="seekfile_tag",
-                      default="",
-                      metavar="<seekfile_tag>",
-                      help="Add a tag in the seek files names, to prevent names collisions. Useful to avoid maintaining many '-S' temporary directories when you check the same files several times with different options.")
-    parser.add_option("-I", "--trace-inode",
-                      action="store_true",
-                      dest="trace_inode",
-                      default=False,
-                      help="Trace the inode of log files. If set, use inode information as a seek file.")
-    parser.add_option("-p", "--pattern",
-                      action="store",
-                      dest="pattern",
-                      metavar="<pattern>",
-                      help="The regular expression to scan for in the log file.")
-    parser.add_option("-P", "--patternfile",
-                      action="store",
-                      dest="patternfile",
-                      metavar="<filename>",
-                      help="File containing regular expressions, one per line.")
-    parser.add_option("--critical-pattern",
-                      action="store",
-                      dest="critical_pattern",
-                      metavar="<pattern>",
-                      help="The regular expression to scan for in the log file. In spite of --critical option, return CRITICAL.")
-    parser.add_option("--critical-patternfile",
-                      action="store",
-                      dest="critical_patternfile",
-                      metavar="<filename>",
-                      help="File containing regular expressions, one per line. In spite of --critical option, return CRITICAL.")
-    parser.add_option("-n", "--negpattern",
-                      action="store",
-                      dest="negpattern",
-                      metavar="<pattern>",
-                      help="The regular expression to skip except as critical pattern in the log file.")
-    parser.add_option("-N", "-f", "--negpatternfile",
-                      action="store",
-                      dest="negpatternfile",
-                      metavar="<filename>",
-                      help="Specifies a file with regular expressions which all will be skipped except as critical pattern, one per line.")
-    parser.add_option("--critical-negpattern",
-                      action="store",
-                      dest="critical_negpattern",
-                      metavar="<pattern>",
-                      help="The regular expression to skip in the log file")
-    parser.add_option("--critical-negpatternfile",
-                      action="store",
-                      dest="critical_negpatternfile",
-                      metavar="<filename>",
-                      help="Specifies a file with regular expressions which all will be skipped, one per line.")
-    parser.add_option("-i", "--case-insensitive",
-                      action="store_true",
-                      dest="case_insensitive",
-                      default=False,
-                      help="Do a case insensitive scan")
-    parser.add_option("--encoding",
-                      action="store",
-                      dest="encoding",
-                      default=None,
-                      metavar="<encoding>",
-                      help="Specify the character encoding in the log file. If not specified, it is treated as it is.")
-    parser.add_option("-w", "--warning",
-                      action="store",
-                      type="int",
-                      dest="warning",
-                      default=1,
-                      metavar="<number>",
-                      help="Return WARNING if at least this many matches found.  The default is %default.")
-    parser.add_option("-c", "--critical",
-                      action="store",
-                      type="int",
-                      dest="critical",
-                      default=0,
-                      metavar="<number>",
-                      help="Return CRITICAL if at least this many matches found.  The default is %default, i.e. don't return critical alerts unless specified explicitly.")
-    parser.add_option("-d", "--nodiff-warn",
-                      action="store_true",
-                      dest="nodiff_warn",
-                      default=False,
-                      help="Return WARNING if the log file was not written to since the last scan. (not implemented)")
-    parser.add_option("-D", "--nodiff-crit",
-                      action="store_true",
-                      dest="nodiff_crit",
-                      default=False,
-                      help="Return CRITICAL if the log was not written to since the last scan. (not impremented)")
-    parser.add_option("-t", "--scantime",
-                      action="store",
-                      type="int",
-                      dest="scantime",
-                      default=86400,
-                      metavar="<seconds>",
-                      help="The range of time to scan. The log files older than this time are not scanned. Default is %default.")
-    parser.add_option("-E", "--expiration",
-                      action="store",
-                      type="int",
-                      dest="expiration",
-                      default=691200,
-                      metavar="<seconds>",
-                      help="The expiration of seek files. Default is %default. This value must be greater than period of log rotation when use with -R option.")
-    parser.add_option("-R", "--remove-seekfile",
-                      action="store_true",
-                      dest="remove_seekfile",
-                      default=False,
-                      help="Remove expired seek files. See also --expiration.")
-    parser.add_option("-M", "--multiline",
-                      action="store_true",
-                      dest="multiline",
-                      default=False,
-                      help="Consider multiple lines with same key as one log output. See also --multiline.")
-    parser.add_option("--cache",
-                      action="store_true",
-                      dest="cache",
-                      default=False,
-                      help="Cache the result for the period specified by the option --cachetime.")
-    parser.add_option("--cachetime",
-                      action="store",
-                      type="int",
-                      dest="cachetime",
-                      default=60,
-                      metavar="<seconds>",
-                      help="The period to cache the result. Default is %default.")
-    parser.add_option("--lock-timeout",
-                      action="store",
-                      type="int",
-                      dest="lock_timeout",
-                      default=3,
-                      metavar="<seconds>",
-                      help="If another proccess is running, wait for the period of this lock timeout. Default is %default.")
-    parser.add_option("--debug",
-                      action="store_true",
-                      dest="debug",
-                      default=False,
-                      help="Enable debug.")
+    parser = argparse.ArgumentParser(
+        description="A log file regular expression-based parser plugin for Nagios.",
+        usage="%(prog)s [option ...]")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s {0}".format(CHECK_LOG_NG_VERSION))
+    parser.add_argument(
+        "-l", "--logfile",
+        action="store",
+        dest="logfile_pattern",
+        metavar="<filename>",
+        help="The pattern of log files to be scanned. " \
+            + "The metacharacter * and ? are allowed. " \
+            + "If you want to set multiple patterns, set a space between patterns.")
+    parser.add_argument(
+        "-F", "--format",
+        action="store",
+        dest="logformat",
+        metavar="<format>",
+        default=LogChecker.FORMAT_SYSLOG,
+        help="The regular expression of format of log to parse. " \
+            + "Required two group, format of '^(TIMESTAMP and TAG)(.*)$'. " \
+            + "Also, may use %%%%, %%Y, %%y, %%a, %%b, %%m, %%d, %%e, %%H, " \
+            + "%%M, %%S, %%F and %%T of strftime(3). " \
+            + "(default: the regular expression for syslog.")
+    parser.add_argument(
+        "-s", "--seekfile",
+        action="store",
+        dest="seekfile",
+        metavar="<filename>",
+        help="The temporary file to store the seek position of the last scan. " \
+            + "If check multiple log files, ignore this option. Use -S seekfile_directory.")
+    parser.add_argument(
+        "-S", "--seekfile-directory",
+        action="store",
+        dest="seekfile_directory",
+        metavar="<seekfile_directory>",
+        help="The directory of the temporary file to store the seek position of the last scan. " \
+            + "If check multiple log files, require this option.")
+    parser.add_argument(
+        "-T", "--seekfile-tag",
+        action="store",
+        dest="seekfile_tag",
+        default="",
+        metavar="<seekfile_tag>",
+        help="Add a tag in the seek files names, to prevent names collisions. " \
+            + "Useful to avoid maintaining many '-S' temporary directories " \
+            + "when you check the same files several times with different args.")
+    parser.add_argument(
+        "-I", "--trace-inode",
+        action="store_true",
+        dest="trace_inode",
+        default=False,
+        help="Trace the inode of log files. If set, use inode information as a seek file.")
+    parser.add_argument(
+        "-p", "--pattern",
+        action="store",
+        dest="pattern",
+        metavar="<pattern>",
+        help="The regular expression to scan for in the log file.")
+    parser.add_argument(
+        "-P", "--patternfile",
+        action="store",
+        dest="patternfile",
+        metavar="<filename>",
+        help="File containing regular expressions, one per line.")
+    parser.add_argument(
+        "--critical-pattern",
+        action="store",
+        dest="critical_pattern",
+        metavar="<pattern>",
+        help="The regular expression to scan for in the log file. " \
+            + "In spite of --critical option, return CRITICAL.")
+    parser.add_argument(
+        "--critical-patternfile",
+        action="store",
+        dest="critical_patternfile",
+        metavar="<filename>",
+        help="File containing regular expressions, one per line. " \
+            + "In spite of --critical option, return CRITICAL.")
+    parser.add_argument(
+        "-n", "--negpattern",
+        action="store",
+        dest="negpattern",
+        metavar="<pattern>",
+        help="The regular expression to skip except as critical pattern in the log file.")
+    parser.add_argument(
+        "-N", "-f", "--negpatternfile",
+        action="store",
+        dest="negpatternfile",
+        metavar="<filename>",
+        help="Specify a file with regular expressions " \
+            + "which all will be skipped except as critical pattern, one per line.")
+    parser.add_argument(
+        "--critical-negpattern",
+        action="store",
+        dest="critical_negpattern",
+        metavar="<pattern>",
+        help="The regular expression to skip in the log file.")
+    parser.add_argument(
+        "--critical-negpatternfile",
+        action="store",
+        dest="critical_negpatternfile",
+        metavar="<filename>",
+        help="Specifiy a file with regular expressions which all will be skipped, one per line.")
+    parser.add_argument(
+        "-i", "--case-insensitive",
+        action="store_true",
+        dest="case_insensitive",
+        default=False,
+        help="Do a case insensitive scan.")
+    parser.add_argument(
+        "--encoding",
+        action="store",
+        dest="encoding",
+        default='utf-8',
+        metavar="<encoding>",
+        help="Specify the character encoding in the log file." \
+            + " (default: %(default)s)")
+    parser.add_argument(
+        "-w", "--warning",
+        action="store",
+        type=int,
+        dest="warning",
+        default=1,
+        metavar="<number>",
+        help="Return WARNING if at least this many matches found." \
+            + " (default: %(default)s)")
+    parser.add_argument(
+        "-c", "--critical",
+        action="store",
+        type=int,
+        dest="critical",
+        default=0,
+        metavar="<number>",
+        help="Return CRITICAL if at least this many matches found. " \
+            + "i.e. don't return critical alerts unless specified explicitly." \
+            + " (default: %(default)s)")
+    parser.add_argument(
+        "-d", "--nodiff-warn",
+        action="store_true",
+        dest="nodiff_warn",
+        default=False,
+        help="Return WARNING if the log file was not written to since the last scan. " \
+            + " (not implemented)")
+    parser.add_argument(
+        "-D", "--nodiff-crit",
+        action="store_true",
+        dest="nodiff_crit",
+        default=False,
+        help="Return CRITICAL if the log was not written to since the last scan. " \
+            + " (not impremented)")
+    parser.add_argument(
+        "-t", "--scantime",
+        action="store",
+        type=int,
+        dest="scantime",
+        default=86400,
+        metavar="<seconds>",
+        help="The range of time to scan. The log files older than this time are not scanned." \
+            + " (default: %(default)s)")
+    parser.add_argument(
+        "-E", "--expiration",
+        action="store",
+        type=int,
+        dest="expiration",
+        default=691200,
+        metavar="<seconds>",
+        help="The expiration of seek files. " \
+            + "This value must be greater than period of log rotation when use with -R option." \
+            + " (default: %(default)s)")
+    parser.add_argument(
+        "-R", "--remove-seekfile",
+        action="store_true",
+        dest="remove_seekfile",
+        default=False,
+        help="Remove expired seek files. See also --expiration.")
+    parser.add_argument(
+        "-M", "--multiline",
+        action="store_true",
+        dest="multiline",
+        default=False,
+        help="Consider multiple lines with same key as one log output. See also --multiline.")
+    parser.add_argument(
+        "--cache",
+        action="store_true",
+        dest="cache",
+        default=False,
+        help="Cache the result for the period specified by the option --cachetime.")
+    parser.add_argument(
+        "--cachetime",
+        action="store",
+        type=int,
+        dest="cachetime",
+        default=60,
+        metavar="<seconds>",
+        help="The period to cache the result." \
+            + " (default: %(default)s)")
+    parser.add_argument(
+        "--lock-timeout",
+        action="store",
+        type=int,
+        dest="lock_timeout",
+        default=3,
+        metavar="<seconds>",
+        help="If another proccess is running, wait for the period of this lock timeout. " \
+            + " (default: %(default)s)")
     return parser
 
 
-def _check_parser_options(parser):
-    global debug
-    (options, args) = parser.parse_args()
-    debug = options.debug
+def _check_parser_args(parser):
+    args = parser.parse_args()
 
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(LogChecker.STATE_UNKNOWN)
 
     # check args
-    if not options.logfile_pattern:
+    if not args.logfile_pattern:
         parser.error("option -l, --logfile is required.")
         sys.exit(LogChecker.STATE_UNKNOWN)
-    if options.seekfile and options.seekfile_directory:
-        parser.error("options '-s, --seekfile' and '-S, --seekfile-directory' are incompatible.\
+    if args.seekfile and args.seekfile_directory:
+        parser.error("args '-s, --seekfile' and '-S, --seekfile-directory' are incompatible.\
                 If check multiple log files, Use -S. If check single log file, Use -s or -S.")
         sys.exit(LogChecker.STATE_UNKNOWN)
 
-    is_multiple_logfiles = LogChecker.is_multiple_logfiles(options.logfile_pattern)
+    is_multiple_logfiles = LogChecker.is_multiple_logfiles(args.logfile_pattern)
     if is_multiple_logfiles:
-        if options.seekfile:
-            parser.error("If check multiple log files, options -s, --seekfile cannot be specified.")
+        if args.seekfile:
+            parser.error("If check multiple log files, " \
+                + "option `-s, --seekfile` cannot be specified.")
             sys.exit(LogChecker.STATE_UNKNOWN)
-        if not options.seekfile_directory:
-            parser.error("If check multiple log files, option -S, --seekfile-directory is required.")
-            sys.exit(LogChecker.STATE_UNKNOWN)
-        if not options.seekfile and not options.seekfile_directory:
-            parser.error("options '-S, --seekfile-directory' is required.")
+        if not args.seekfile_directory:
+            parser.error("If check multiple log files, " \
+                + "option `-S, --seekfile-directory` is required.")
             sys.exit(LogChecker.STATE_UNKNOWN)
         # check directory
-        if options.seekfile_directory and not os.path.isdir(options.seekfile_directory):
-            parser.error("seekfile directory is not found: %s" % (options.seekfile_directory))
+        if not os.path.isdir(args.seekfile_directory):
+            parser.error("seekfile directory is not found: {0}".format(args.seekfile_directory))
             sys.exit(LogChecker.STATE_UNKNOWN)
     else:
-        if not options.seekfile and not options.seekfile_directory:
-            parser.error("options '-S, --seekfile-directory' or '-s, --seekfile' is required.")
+        if not args.seekfile and not args.seekfile_directory:
+            parser.error("option `-S, --seekfile-directory` or `-s, --seekfile` is required.")
             sys.exit(LogChecker.STATE_UNKNOWN)
         # check file or directory
-        if options.seekfile_directory and not os.path.isdir(options.seekfile_directory):
-            parser.error("seekfile directory is not found: %s" % (options.seekfile_directory))
+        if args.seekfile_directory and not os.path.isdir(args.seekfile_directory):
+            parser.error("seekfile directory is not found: {0}".format(args.seekfile_directory))
             sys.exit(LogChecker.STATE_UNKNOWN)
-        if options.seekfile and not os.path.isfile(options.logfile_pattern):
-            parser.error("logfile is not found: %s" % (options.logfile_pattern))
+        if args.seekfile and not os.path.isfile(args.logfile_pattern):
+            parser.error("logfile is not found: {0}".format(args.logfile_pattern))
             sys.exit(LogChecker.STATE_UNKNOWN)
 
-    pattern_list = LogChecker.get_pattern_list(options.pattern, options.patternfile)
+    pattern_list = LogChecker.get_pattern_list(args.pattern, args.patternfile)
     critical_pattern_list = LogChecker.get_pattern_list(
-        options.critical_pattern, options.critical_patternfile)
+        args.critical_pattern, args.critical_patternfile)
     if not pattern_list and not critical_pattern_list:
-        parser.error("any valid pattern not found")
+        parser.error("any valid pattern does not found")
         sys.exit(LogChecker.STATE_UNKNOWN)
 
-    return (options, args)
+    return args
 
 
-def _generate_initial_data(options):
+def _generate_initial_data(args):
     """Generate initial data."""
     # make pattern list
-    pattern_list = LogChecker.get_pattern_list(options.pattern, options.patternfile)
+    pattern_list = LogChecker.get_pattern_list(args.pattern, args.patternfile)
     critical_pattern_list = LogChecker.get_pattern_list(
-        options.critical_pattern, options.critical_patternfile)
+        args.critical_pattern, args.critical_patternfile)
     negpattern_list = LogChecker.get_pattern_list(
-        options.negpattern, options.negpatternfile)
+        args.negpattern, args.negpatternfile)
     critical_negpattern_list = LogChecker.get_pattern_list(
-        options.critical_negpattern, options.critical_negpatternfile)
+        args.critical_negpattern, args.critical_negpatternfile)
 
-    # set value of options
+    # set value of args
     initial_data = {
-        "logformat": options.logformat,
+        "logformat": args.logformat,
         "pattern_list": pattern_list,
         "critical_pattern_list": critical_pattern_list,
         "negpattern_list": negpattern_list,
         "critical_negpattern_list": critical_negpattern_list,
-        "case_insensitive": options.case_insensitive,
-        "encoding": options.encoding,
-        "warning": options.warning,
-        "critical": options.critical,
-        "nodiff_warn": options.nodiff_warn,
-        "nodiff_crit": options.nodiff_crit,
-        "trace_inode": options.trace_inode,
-        "multiline": options.multiline,
-        "scantime": options.scantime,
-        "expiration": options.expiration,
-        "cache": options.cache,
-        "cachetime": options.cachetime,
-        "lock_timeout": options.lock_timeout
+        "case_insensitive": args.case_insensitive,
+        "encoding": args.encoding,
+        "warning": args.warning,
+        "critical": args.critical,
+        "nodiff_warn": args.nodiff_warn,
+        "nodiff_crit": args.nodiff_crit,
+        "trace_inode": args.trace_inode,
+        "multiline": args.multiline,
+        "scantime": args.scantime,
+        "expiration": args.expiration,
+        "cache": args.cache,
+        "cachetime": args.cachetime,
+        "lock_timeout": args.lock_timeout
     }
     return initial_data
 
@@ -903,15 +923,15 @@ def _generate_initial_data(options):
 def main():
     """Main function."""
     parser = _make_parser()
-    (options, _) = _check_parser_options(parser)
+    args = _check_parser_args(parser)
 
-    initial_data = _generate_initial_data(options)
+    initial_data = _generate_initial_data(args)
     log = LogChecker(initial_data)
-    log.check(options.logfile_pattern, options.seekfile,
-              options.seekfile_directory, options.remove_seekfile,
-              options.seekfile_tag)
+    log.check(args.logfile_pattern, args.seekfile,
+              args.seekfile_directory, args.remove_seekfile,
+              args.seekfile_tag)
     state = log.get_state()
-    print log.get_message()
+    print(log.get_message())
     sys.exit(state)
 
 

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -100,11 +100,26 @@ class LogChecker(object):
 
         return True
 
-    def _find_pattern(self, pattern_list, message, negative=False, critical=False):
+    def _find_pattern(self, message, negative=False, critical=False):
         """Find pattern.
 
            If found, return True.
         """
+        if negative:
+            if critical:
+                pattern_list = self.critical_negpattern_list
+                pattern_type = "critical_negpattern"
+            else:
+                pattern_list = self.negpattern_list
+                pattern_type = "negpattern"
+        else:
+            if critical:
+                pattern_list = self.critical_pattern_list
+                pattern_type = "critical_pattern"
+            else:
+                pattern_list = self.pattern_list
+                pattern_type = "pattern"
+
         if not pattern_list:
             return False
         for pattern in pattern_list:
@@ -113,16 +128,7 @@ class LogChecker(object):
             pattern = LogChecker.to_unicode(pattern)
             matchobj = re.search(pattern, message, self.pattern_flags)
             if matchobj:
-                if negative:
-                    if critical:
-                        _debug("critical_negpattern: '{0}' found".format(pattern))
-                    else:
-                        _debug("negpattern: '{0}' found".format(pattern))
-                else:
-                    if critical:
-                        _debug("critical_pattern: '{0}' found".format(pattern))
-                    else:
-                        _debug("pattern: '{0}' found".format(pattern))
+                _debug("{0}: '{1}' found".format(pattern_type, pattern))
                 return True
         return False
 
@@ -231,16 +237,14 @@ class LogChecker(object):
 
     def _set_found(self, message, found, critical_found):
         """Set the found and critical_found if matching pattern is found."""
-        found_negpattern = self._find_pattern(
-            self.negpattern_list, message, negative=True)
-        found_critical_negpattern = self._find_pattern(
-            self.critical_negpattern_list, message, negative=True, critical=True)
+        found_negpattern = self._find_pattern(message, negative=True)
+        found_critical_negpattern = self._find_pattern(message, negative=True, critical=True)
 
         if not found_negpattern and not found_critical_negpattern:
-            if self._find_pattern(self.pattern_list, message):
+            if self._find_pattern(message):
                 found.append(message)
         if not found_critical_negpattern:
-            if self._find_pattern(self.critical_pattern_list, message, critical=True):
+            if self._find_pattern(message, critical=True):
                 critical_found.append(message)
         return
 

--- a/test_check_log_ng.py
+++ b/test_check_log_ng.py
@@ -2,8 +2,14 @@
 # -*- coding: utf-8 -*-
 """Unit test for check_log_ng"""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import unittest
+import warnings
 import os
+import io
 import time
 import subprocess
 from check_log_ng import LogChecker
@@ -129,7 +135,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("[Thu Dec 05 12:34:56 2013] [error] NOOP\n")
         fileobj.write("[Thu Dec 05 12:34:56 2013] [error] ERROR\n")
         fileobj.write("[Thu Dec 05 12:34:57 2013] [error] NOOP\n")
@@ -139,7 +145,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): [Thu Dec 05 12:34:56 2013] [error] ERROR at %s" % self.logfile)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): [Thu Dec 05 12:34:56 2013] [error] ERROR at {0}".format(self.logfile))
 
     def test_pattern(self):
         """--pattern option
@@ -162,7 +168,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
@@ -172,7 +178,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at {0}".format(self.logfile))
 
     def test_pattern_no_matches(self):
         """--pattern option
@@ -195,7 +201,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
         fileobj.flush()
@@ -204,7 +210,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), 'OK - No matches found.')
+        self.assertEqual(log.get_message(), "OK - No matches found.")
 
     def test_pattern_with_case_insensitive(self):
         """--pattern and --case-insensitive options
@@ -227,7 +233,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
@@ -237,7 +243,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at {0}".format(self.logfile))
 
     def test_pattern_with_encoding(self):
         """--pattern and --encoding
@@ -261,9 +267,9 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='w', encoding='EUC-JP')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write(u"Dec  5 12:34:56 hostname test: エラー\n".encode("EUC-JP"))
+        fileobj.write("Dec  5 12:34:56 hostname test: エラー\n")
         fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
         fileobj.flush()
         fileobj.close()
@@ -271,7 +277,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: エラー at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: エラー at {0}".format(self.logfile))
 
     def test_criticalpattern(self):
         """--criticalpattern option
@@ -294,7 +300,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
@@ -304,7 +310,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_CRITICAL)
-        self.assertEqual(log.get_message(), 'CRITICAL: Critical Found 1 lines: Dec  5 12:34:56 hostname test: ERROR at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "CRITICAL: Critical Found 1 lines: Dec  5 12:34:56 hostname test: ERROR at {0}".format(self.logfile))
 
     def test_criticalpattern_with_negpattern(self):
         """--criticalpattern option
@@ -327,7 +333,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:56 hostname test: ERROR IGNORE\n")
         fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
@@ -337,7 +343,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_CRITICAL)
-        self.assertEqual(log.get_message(), 'CRITICAL: Critical Found 1 lines: Dec  5 12:34:56 hostname test: ERROR IGNORE at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "CRITICAL: Critical Found 1 lines: Dec  5 12:34:56 hostname test: ERROR IGNORE at {0}".format(self.logfile))
 
     def test_criticalpattern_with_case_sensitive(self):
         """--criticalpattern and --case-insensitive options
@@ -360,7 +366,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
@@ -370,7 +376,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_CRITICAL)
-        self.assertEqual(log.get_message(), 'CRITICAL: Critical Found 1 lines: Dec  5 12:34:56 hostname test: ERROR at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "CRITICAL: Critical Found 1 lines: Dec  5 12:34:56 hostname test: ERROR at {0}".format(self.logfile))
 
     def test_negpattern(self):
         """--negpattern option
@@ -393,7 +399,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:56 hostname test: ERROR IGNORE\n")
         fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
@@ -403,7 +409,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), 'OK - No matches found.')
+        self.assertEqual(log.get_message(), "OK - No matches found.")
 
     def test_critical_negpattern(self):
         """--critical-negpattern option
@@ -426,7 +432,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:56 hostname test: FATAL ERROR IGNORE\n")
         fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
@@ -436,7 +442,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), 'OK - No matches found.')
+        self.assertEqual(log.get_message(), "OK - No matches found.")
 
     def test_critical_negpattern_with_pattern(self):
         """--criticalpattern option
@@ -459,7 +465,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:56 hostname test: IGNORE FATAL\n")
         fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
@@ -469,7 +475,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), 'OK - No matches found.')
+        self.assertEqual(log.get_message(), "OK - No matches found.")
 
     def test_critical_negpattern_with_pattern_and_criticalpattern(self):
         """--criticalpattern option
@@ -492,7 +498,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:56 hostname test: ERROR IGNORE FATAL\n")
         fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
@@ -502,7 +508,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), 'OK - No matches found.')
+        self.assertEqual(log.get_message(), "OK - No matches found.")
 
     def test_negpattern_with_case_insensitive(self):
         """--negpattern and --case-insensitive options
@@ -525,7 +531,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:56 hostname test: ERROR IGNORE\n")
         fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
@@ -535,7 +541,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), 'OK - No matches found.')
+        self.assertEqual(log.get_message(), "OK - No matches found.")
 
     def test_pattern_with_multiple_lines(self):
         """--pattern options with multiples lines
@@ -558,7 +564,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:56 hostname test: ERROR1\n")
         fileobj.write("Dec  5 12:34:56 hostname test: ERROR2\n")
@@ -569,7 +575,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR1 ERROR2 at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR1 ERROR2 at {0}".format(self.logfile))
 
     def test_negpattern_with_multiple_lines(self):
         """--negpattern options with multiple lines
@@ -592,7 +598,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:56 hostname test: ERROR IGNORE\n")
         fileobj.flush()
@@ -643,7 +649,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=False)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 2 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at %s,Dec  5 12:34:59 hostname test: ERROR at %s' % (self.logfile1, self.logfile2))
+        self.assertEqual(log.get_message(), "WARNING: Found 2 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at {0},Dec  5 12:34:59 hostname test: ERROR at {1}".format(self.logfile1, self.logfile2))
 
     def test_logfile_with_filename(self):
         """--logfile option with multiple filenames
@@ -682,11 +688,11 @@ class TestSequenceFunctions(unittest.TestCase):
         fileobj.flush()
         fileobj.close()
 
-        logfile_pattern = "%s %s" % (self.logfile1, self.logfile2)
+        logfile_pattern = "{0} {1}".format(self.logfile1, self.logfile2)
         log.check_log_multi(logfile_pattern, self.seekdir, remove_seekfile=False)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 2 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at %s,Dec  5 12:34:59 hostname test: ERROR at %s' % (self.logfile1, self.logfile2))
+        self.assertEqual(log.get_message(), "WARNING: Found 2 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at {0},Dec  5 12:34:59 hostname test: ERROR at {1}".format(self.logfile1, self.logfile2))
 
     def test_scantime_without_scantime(self):
         """--scantime option without scantime.
@@ -754,7 +760,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=False)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at %s' % self.logfile1)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at {0}".format(self.logfile1))
 
     def test_scantime_with_multiple_logfiles(self):
         """--scantime option with multiple logfiles.
@@ -797,7 +803,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=False)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at %s' % self.logfile2)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at {0}".format(self.logfile2))
 
     def test_remove_seekfile_without_expiration(self):
         """--expiration and --remove-seekfile options
@@ -842,7 +848,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=True)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at %s' % self.logfile2)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at {0}".format(self.logfile2))
         self.assertFalse(os.path.exists(self.seekfile1))
         self.assertTrue(os.path.exists(self.seekfile2))
 
@@ -889,7 +895,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=True)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at %s' % self.logfile2)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at {0}".format(self.logfile2))
         self.assertTrue(os.path.exists(self.seekfile1))
         self.assertTrue(os.path.exists(self.seekfile2))
 
@@ -915,7 +921,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log = LogChecker(initial_data)
 
         # create logfile
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
@@ -929,7 +935,7 @@ class TestSequenceFunctions(unittest.TestCase):
             self.logfile_pattern, self.seekdir, self.logfile, trace_inode=True)
 
         # update logfile
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:55 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:55 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
@@ -940,7 +946,7 @@ class TestSequenceFunctions(unittest.TestCase):
         os.rename(self.logfile, self.logfile1)
 
         # create a new logfile
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:59 hostname noop: NOOP\n")
         fileobj.flush()
         fileobj.close()
@@ -953,7 +959,7 @@ class TestSequenceFunctions(unittest.TestCase):
             self.logfile_pattern, self.seekdir, self.logfile1, trace_inode=True)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:55 hostname test: ERROR at %s' % self.logfile1)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:55 hostname test: ERROR at {0}".format(self.logfile1))
         self.assertEqual(seekfile_1, seekfile1_2)
         self.assertTrue(os.path.exists(seekfile_2))
         self.assertTrue(os.path.exists(seekfile1_2))
@@ -980,7 +986,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log = LogChecker(initial_data)
 
         # create logfile
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:50 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
@@ -991,7 +997,7 @@ class TestSequenceFunctions(unittest.TestCase):
         os.rename(self.logfile, self.logfile1)
 
         # create new logfile
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:53 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:53 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:54 hostname noop: NOOP\n")
@@ -1008,7 +1014,7 @@ class TestSequenceFunctions(unittest.TestCase):
         time.sleep(4)
 
         # update logfile
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:58 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:59 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:59 hostname noop: NOOP\n")
@@ -1025,7 +1031,7 @@ class TestSequenceFunctions(unittest.TestCase):
             self.logfile_pattern, self.seekdir, self.logfile1, trace_inode=True)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at %s' % self.logfile1)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at {0}".format(self.logfile1))
         self.assertEqual(seekfile_1, seekfile1_2)
         self.assertFalse(os.path.exists(seekfile1_1))
         self.assertTrue(os.path.exists(seekfile1_2))
@@ -1051,7 +1057,7 @@ class TestSequenceFunctions(unittest.TestCase):
         }
         log = LogChecker(initial_data)
 
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec | 5 12:34:56 hostname noop: NOOP\n")
         fileobj.write("Dec | 5 12:34:56 hostname test: ERROR\n")
         fileobj.write("Dec | 5 12:34:57 hostname noop: NOOP\n")
@@ -1061,7 +1067,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec (pipe) 5 12:34:56 hostname test: ERROR at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec (pipe) 5 12:34:56 hostname test: ERROR at {0}".format(self.logfile))
 
     def test_seekfile_tag(self):
         """--seekfile-tag
@@ -1085,7 +1091,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log = LogChecker(initial_data)
 
         # create new logfiles
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
@@ -1117,7 +1123,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check_log_multi(self.logfile_pattern, self.seekdir, seekfile_tag=self.tag2)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at %s' % self.logfile1)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at {0}".format(self.logfile1))
         self.assertEqual(seekfile_1, seekfile_2)
         self.assertNotEqual(seekfile_1, seekfile_3)
         self.assertTrue(seekfile_1.find(self.tag1))
@@ -1147,7 +1153,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log = LogChecker(initial_data)
 
         # create new logfiles
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
@@ -1157,7 +1163,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log.check(self.logfile, '', self.seekdir)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at {0}".format(self.logfile))
 
         log.clear_state()
         log.check(self.logfile, '', self.seekdir)
@@ -1187,7 +1193,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log = LogChecker(initial_data)
 
         # create new logfiles
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
@@ -1196,12 +1202,12 @@ class TestSequenceFunctions(unittest.TestCase):
 
         log.check(self.logfile, '', self.seekdir)
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at {0}".format(self.logfile))
 
         log.clear_state()
         log.check(self.logfile, '', self.seekdir)
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at {0}".format(self.logfile))
 
     def test_check_with_expired_cache(self):
         """--cache --cachetime=1
@@ -1227,7 +1233,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log = LogChecker(initial_data)
 
         # create new logfiles
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
@@ -1236,7 +1242,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
         log.check(self.logfile, '', self.seekdir)
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at {0}".format(self.logfile))
 
         log.clear_state()
         time.sleep(2)
@@ -1268,7 +1274,7 @@ class TestSequenceFunctions(unittest.TestCase):
         log = LogChecker(initial_data)
 
         # create new logfiles
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
@@ -1279,18 +1285,18 @@ class TestSequenceFunctions(unittest.TestCase):
         lockfile = "".join([prefix_datafile, LogChecker.SUFFIX_LOCK])
         code = """import time
 from check_log_ng import LogChecker
-lockfile = '%s'
+lockfile = '{0}'
 lockfileobj = LogChecker.lock(lockfile)
 time.sleep(5)
 LogChecker.unlock(lockfile, lockfileobj)
-""" % lockfile
+""".format(lockfile)
         code = code.replace("\n", ";")
         proc = subprocess.Popen(['python', '-c', code])
         time.sleep(2)
         log.check(self.logfile, '', self.seekdir)
         proc.wait()
         self.assertEqual(log.get_state(), LogChecker.STATE_UNKNOWN)
-        self.assertEqual(log.get_message(), 'UNKNOWN: Lock timeout. Another process is running.')
+        self.assertEqual(log.get_message(), "UNKNOWN: Lock timeout. Another process is running.")
 
     def test_lock_timeout_without_timeout(self):
         """--lock-timeout without timeout
@@ -1317,7 +1323,7 @@ LogChecker.unlock(lockfile, lockfileobj)
         log = LogChecker(initial_data)
 
         # create new logfiles
-        fileobj = open(self.logfile, 'a')
+        fileobj = io.open(self.logfile, mode='a')
         fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
         fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
         fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
@@ -1328,18 +1334,18 @@ LogChecker.unlock(lockfile, lockfileobj)
         lockfile = "".join([prefix_datafile, LogChecker.SUFFIX_LOCK])
         code = """import time
 from check_log_ng import LogChecker
-lockfile = '%s'
+lockfile = '{0}'
 lockfileobj = LogChecker.lock(lockfile)
 time.sleep(3)
 LogChecker.unlock(lockfile, lockfileobj)
-""" % lockfile
+""".format(lockfile)
         code = code.replace("\n", ";")
         proc = subprocess.Popen(['python', '-c', code])
         time.sleep(2)
         log.check(self.logfile, '', self.seekdir)
         proc.wait()
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), 'WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at %s' % self.logfile)
+        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at {0}".format(self.logfile))
 
     def test_get_prefix_datafile(self):
         """LogChecker.get_prefix_datafile()
@@ -1360,6 +1366,7 @@ LogChecker.unlock(lockfile, lockfileobj)
         lockfile = "".join([prefix_datafile, LogChecker.SUFFIX_LOCK])
         lockfileobj = LogChecker.lock(lockfile)
         self.assertNotEqual(lockfileobj, None)
+        LogChecker.unlock(lockfile, lockfileobj)
 
     def test_lock_with_timeout(self):
         """LogChecker.lock() with timeout.
@@ -1368,15 +1375,17 @@ LogChecker.unlock(lockfile, lockfileobj)
         lockfile = "".join([prefix_datafile, LogChecker.SUFFIX_LOCK])
         code = """import time
 from check_log_ng import LogChecker
-lockfile = '%s'
+lockfile = '{0}'
 lockfileobj = LogChecker.lock(lockfile)
 time.sleep(4)
 LogChecker.unlock(lockfile, lockfileobj)
-""" % lockfile
+""".format(lockfile)
         code = code.replace("\n", ";")
         proc = subprocess.Popen(['python', '-c', code])
         time.sleep(2)
-        lockfileobj = LogChecker.lock(lockfile)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            lockfileobj = LogChecker.lock(lockfile)
         proc.wait()
         self.assertEqual(lockfileobj, None)
 

--- a/test_check_log_ng.py
+++ b/test_check_log_ng.py
@@ -11,1027 +11,620 @@ import warnings
 import os
 import io
 import time
+import datetime
 import subprocess
 from check_log_ng import LogChecker
 
 
-class TestSequenceFunctions(unittest.TestCase):
+class LogCheckerTestCase(unittest.TestCase):
 
     """Unit test."""
 
+    # Class constant
+    MESSAGE_OK = "OK - No matches found."
+    MESSAGE_WARNING_ONE = "WARNING: Found 1 lines (limit=1/0): {0} at {1}"
+    MESSAGE_WARNING_TWO = "WARNING: Found 2 lines (limit=1/0): {0},{1} at {2}"
+    MESSAGE_WARNING_TWO_IN_TWO_FILES = (
+        "WARNING: Found 2 lines (limit=1/0): {0} at {1},{2} at {3}")
+    MESSAGE_CRITICAL_ONE = "CRITICAL: Critical Found 1 lines: {0} at {1}"
+    MESSAGE_UNKNOWN_LOCK_TIMEOUT = (
+        "UNKNOWN: Lock timeout. Another process is running.")
+
+    # Class variablesex
+    BASEDIR = None
+    TESTDIR = None
+    LOGDIR = None
+    SEEKDIR = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.BASEDIR = os.getcwd()
+        cls.TESTDIR = os.path.join(cls.BASEDIR, 'test')
+        cls.LOGDIR = os.path.join(cls.TESTDIR, 'log')
+        cls.SEEKDIR = os.path.join(cls.TESTDIR, 'seek')
+        if not os.path.isdir(cls.TESTDIR):
+            os.mkdir(cls.TESTDIR)
+        if not os.path.isdir(cls.LOGDIR):
+            os.mkdir(cls.LOGDIR)
+        if not os.path.isdir(cls.SEEKDIR):
+            os.mkdir(cls.SEEKDIR)
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(cls.LOGDIR):
+            os.removedirs(cls.LOGDIR)
+        if os.path.exists(cls.SEEKDIR):
+            os.removedirs(cls.SEEKDIR)
+        if os.path.exists(cls.TESTDIR):
+            os.removedirs(cls.TESTDIR)
+
     def setUp(self):
-        curdir = os.getcwd()
-        testdir = os.path.join(curdir, 'test')
-        self.testdir = testdir
-        if not os.path.isdir(testdir):
-            os.mkdir(testdir)
+        # log files
+        self.logfile = os.path.join(self.LOGDIR, 'testlog')
+        self.logfile1 = os.path.join(self.LOGDIR, 'testlog.1')
+        self.logfile2 = os.path.join(self.LOGDIR, 'testlog.2')
+        self.logfile_pattern = os.path.join(self.LOGDIR, 'testlog*')
 
-        logdir = os.path.join(testdir, 'log')
-        if not os.path.isdir(logdir):
-            os.mkdir(logdir)
-        self.logdir = logdir
-        self.logfile = os.path.join(logdir, 'testlog')
-        self.logfile1 = os.path.join(logdir, 'testlog.1')
-        self.logfile2 = os.path.join(logdir, 'testlog.2')
-        self.logfile_pattern = os.path.join(logdir, 'testlog*')
-
-        self.tag1 = 'test1'
-        self.tag2 = 'test2'
-
-        seekdir = os.path.join(testdir, 'seek')
-        if not os.path.isdir(seekdir):
-            os.mkdir(seekdir)
-        self.seekdir = seekdir
-        self.seekfile = os.path.join(seekdir, 'testlog.seek')
+        # seek files
+        self.tag1 = 'tag1'
+        self.tag2 = 'tag2'
+        self.seekfile = os.path.join(self.SEEKDIR, 'testlog.seek')
         self.seekfile1 = LogChecker.get_seekfile(
-            self.logfile_pattern, seekdir, self.logfile1)
+            self.logfile_pattern, self.SEEKDIR, self.logfile1)
         self.seekfile2 = LogChecker.get_seekfile(
-            self.logfile_pattern, seekdir, self.logfile2)
-        self.seekfile3 = LogChecker.get_seekfile(
-            self.logfile_pattern, seekdir, self.logfile, seekfile_tag=self.tag1)
-        self.seekfile4 = LogChecker.get_seekfile(
-            self.logfile_pattern, seekdir, self.logfile, seekfile_tag=self.tag2)
-        self.seekfile5 = LogChecker.get_seekfile(
-            self.logfile_pattern, seekdir, self.logfile1, seekfile_tag=self.tag2)
-        self.seekfile6 = LogChecker.get_seekfile(
-            self.logfile_pattern, seekdir, self.logfile2, seekfile_tag=self.tag2)
+            self.logfile_pattern, self.SEEKDIR, self.logfile2)
 
-        self.logformat_syslog = LogChecker.FORMAT_SYSLOG
+        # cache file and lock file
+        prefix_datafile = LogChecker.get_prefix_datafile('', self.SEEKDIR)
+        self.cachefile = "".join([prefix_datafile, LogChecker.SUFFIX_CACHE])
+        self.lockfile = "".join([prefix_datafile, LogChecker.SUFFIX_LOCK])
+
+        # configuration
+        self.config = {
+            "logformat": LogChecker.FORMAT_SYSLOG,
+            "pattern_list": [],
+            "critical_pattern_list": [],
+            "negpattern_list": [],
+            "critical_negpattern_list": [],
+            "case_insensitive": False,
+            "encoding": "utf-8",
+            "warning": 1,
+            "critical": 0,
+            "nodiff_warn": False,
+            "nodiff_crit": False,
+            "trace_inode": False,
+            "multiline": False,
+            "scantime": 86400,
+            "expiration": 691200,
+            "cache": False,
+            "cachetime": 60,
+            "lock_timeout": 3
+        }
 
     def tearDown(self):
+        # remove seek files and log files.
         if os.path.exists(self.seekfile):
             os.unlink(self.seekfile)
-        if os.path.exists(self.seekfile1):
-            os.unlink(self.seekfile1)
-        if os.path.exists(self.seekfile2):
-            os.unlink(self.seekfile2)
-        if os.path.exists(self.seekfile3):
-            os.unlink(self.seekfile3)
-        if os.path.exists(self.seekfile4):
-            os.unlink(self.seekfile4)
-        if os.path.exists(self.seekfile5):
-            os.unlink(self.seekfile5)
-        if os.path.exists(self.seekfile6):
-            os.unlink(self.seekfile6)
+        for logfile in [self.logfile, self.logfile1, self.logfile2]:
+            if not os.path.exists(logfile):
+                continue
+            for trace_inode in [True, False]:
+                seekfile = LogChecker.get_seekfile(
+                    self.logfile_pattern, self.SEEKDIR, logfile,
+                    trace_inode=trace_inode)
+                if os.path.exists(seekfile):
+                    os.unlink(seekfile)
+            for seekfile_tag in [self.tag1, self.tag2]:
+                seekfile = LogChecker.get_seekfile(
+                    self.logfile_pattern, self.SEEKDIR, logfile,
+                    seekfile_tag=seekfile_tag)
+                if os.path.exists(seekfile):
+                    os.unlink(seekfile)
+            os.unlink(logfile)
 
-        if os.path.exists(self.logfile):
-            seekfile = LogChecker.get_seekfile(
-                self.logfile_pattern, self.seekdir, self.logfile, trace_inode=True)
-            if os.path.exists(seekfile):
-                os.unlink(seekfile)
-            seekfile = LogChecker.get_seekfile(
-                self.logfile_pattern, self.seekdir, self.logfile, trace_inode=False)
-            if os.path.exists(seekfile):
-                os.unlink(seekfile)
-            os.unlink(self.logfile)
-
-        if os.path.exists(self.logfile1):
-            seekfile1 = LogChecker.get_seekfile(
-                self.logfile_pattern, self.seekdir, self.logfile1, trace_inode=True)
-            if os.path.exists(seekfile1):
-                os.unlink(seekfile1)
-            os.unlink(self.logfile1)
-
-        if os.path.exists(self.logfile2):
-            seekfile2 = LogChecker.get_seekfile(
-                self.logfile_pattern, self.seekdir, self.logfile2, trace_inode=True)
-            if os.path.exists(seekfile2):
-                os.unlink(seekfile2)
-            os.unlink(self.logfile2)
-
-        prefix_datafile = LogChecker.get_prefix_datafile('', self.seekdir)
-        cachefile = "".join([prefix_datafile, LogChecker.SUFFIX_CACHE])
-        lockfile = "".join([prefix_datafile, LogChecker.SUFFIX_LOCK])
-        if os.path.exists(cachefile):
-            os.unlink(cachefile)
-        if os.path.exists(lockfile):
-            os.unlink(lockfile)
-
-        if os.path.exists(self.logdir):
-            os.removedirs(self.logdir)
-        if os.path.exists(self.seekdir):
-            os.removedirs(self.seekdir)
-        if os.path.exists(self.testdir):
-            os.removedirs(self.testdir)
+        # remove cache file and lock file.
+        if os.path.exists(self.cachefile):
+            os.unlink(self.cachefile)
+        if os.path.exists(self.lockfile):
+            os.unlink(self.lockfile)
 
     def test_format(self):
         """--format option
         """
-        initial_data = {
-            "logformat": r"^(\[%a %b %d %T %Y\] \[\S+\]) (.*)$",
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        self.config["logformat"] = r"^(\[%a %b %d %T %Y\] \[\S+\]) (.*)$"
+        self.config["pattern_list"] = ["ERROR"]
+        log = LogChecker(self.config)
 
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("[Thu Dec 05 12:34:56 2013] [error] NOOP\n")
-        fileobj.write("[Thu Dec 05 12:34:56 2013] [error] ERROR\n")
-        fileobj.write("[Thu Dec 05 12:34:57 2013] [error] NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
+        # [Thu Dec 05 12:34:50 2013] [error] ERROR
+        line = self._make_customized_line(
+            self._get_customized_timestamp(), "error", "ERROR")
+        self._write_customized_logfile(self.logfile, line)
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): [Thu Dec 05 12:34:56 2013] [error] ERROR at {0}".format(self.logfile))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line, self.logfile))
 
     def test_pattern(self):
         """--pattern option
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        self.config["pattern_list"] = ["ERROR"]
+        log = LogChecker(self.config)
 
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
+        # 1 line matched
+        # Dec  5 12:34:50 hostname test: ERROR
+        line1 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line1)
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at {0}".format(self.logfile))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line1, self.logfile))
 
-    def test_pattern_no_matches(self):
-        """--pattern option
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        # 2 lines matched
+        # Dec  5 12:34:50 hostname test: ERROR1
+        # Dec  5 12:34:50 hostname test: ERROR2
+        line2 = self._make_line(self._get_timestamp(), "test", "ERROR1")
+        line3 = self._make_line(self._get_timestamp(), "test", "ERROR2")
+        self._write_logfile(self.logfile, [line2, line3])
+        log.clear_state()
+        log.check_log(self.logfile, self.seekfile)
 
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_TWO.format(line2, line3, self.logfile))
 
+        # no line matched
+        # Dec  5 12:34:50 hostname noop: NOOP
+        line4 = self._make_line(self._get_timestamp(), "noop", "NOOP")
+        self._write_logfile(self.logfile, line4)
+        log.clear_state()
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), "OK - No matches found.")
+        self.assertEqual(log.get_message(), self.MESSAGE_OK)
 
-    def test_pattern_with_case_insensitive(self):
-        """--pattern and --case-insensitive options
+    def test_critical_pattern(self):
+        """--critical-pattern option
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["error"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": True,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        self.config["critical_pattern_list"] = ["FATAL"]
+        log = LogChecker(self.config)
 
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        log.check_log(self.logfile, self.seekfile)
-
-        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at {0}".format(self.logfile))
-
-    def test_pattern_with_encoding(self):
-        """--pattern and --encoding
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["エラー"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "encoding": 'EUC-JP',
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
-
-        fileobj = io.open(self.logfile, mode='w', encoding='EUC-JP')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: エラー\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        log.check_log(self.logfile, self.seekfile)
-
-        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: エラー at {0}".format(self.logfile))
-
-    def test_criticalpattern(self):
-        """--criticalpattern option
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": [],
-            "critical_pattern_list": ["ERROR"],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
-
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
+        # Dec  5 12:34:50 hostname test: FATAL
+        line = self._make_line(self._get_timestamp(), "test", "FATAL")
+        self._write_logfile(self.logfile, line)
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_CRITICAL)
-        self.assertEqual(log.get_message(), "CRITICAL: Critical Found 1 lines: Dec  5 12:34:56 hostname test: ERROR at {0}".format(self.logfile))
-
-    def test_criticalpattern_with_negpattern(self):
-        """--criticalpattern option
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": [],
-            "critical_pattern_list": ["ERROR"],
-            "negpattern_list": ["IGNORE"],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
-
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR IGNORE\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        log.check_log(self.logfile, self.seekfile)
-
-        self.assertEqual(log.get_state(), LogChecker.STATE_CRITICAL)
-        self.assertEqual(log.get_message(), "CRITICAL: Critical Found 1 lines: Dec  5 12:34:56 hostname test: ERROR IGNORE at {0}".format(self.logfile))
-
-    def test_criticalpattern_with_case_sensitive(self):
-        """--criticalpattern and --case-insensitive options
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": [],
-            "critical_pattern_list": ["error"],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": True,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
-
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        log.check_log(self.logfile, self.seekfile)
-
-        self.assertEqual(log.get_state(), LogChecker.STATE_CRITICAL)
-        self.assertEqual(log.get_message(), "CRITICAL: Critical Found 1 lines: Dec  5 12:34:56 hostname test: ERROR at {0}".format(self.logfile))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_CRITICAL_ONE.format(line, self.logfile))
 
     def test_negpattern(self):
         """--negpattern option
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": ["IGNORE"],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        self.config["pattern_list"] = ["ERROR"]
+        self.config["critical_pattern_list"] = ["FATAL"]
+        self.config["negpattern_list"] = ["IGNORE"]
+        log = LogChecker(self.config)
 
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR IGNORE\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
+        # check --pattern
+        # Dec  5 12:34:50 hostname test: ERROR IGNORE
+        line1 = self._make_line(self._get_timestamp(), "test", "ERROR IGNORE")
+        self._write_logfile(self.logfile, line1)
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), "OK - No matches found.")
+        self.assertEqual(log.get_message(), self.MESSAGE_OK)
+
+        # check --critical-pattern
+        # Dec  5 12:34:50 hostname test: FATAL IGNORE
+        line2 = self._make_line(self._get_timestamp(), "test", "FATAL IGNORE")
+        self._write_logfile(self.logfile, line2)
+        log.clear_state()
+        log.check_log(self.logfile, self.seekfile)
+
+        self.assertEqual(log.get_state(), LogChecker.STATE_CRITICAL)
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_CRITICAL_ONE.format(line2, self.logfile))
 
     def test_critical_negpattern(self):
         """--critical-negpattern option
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": [],
-            "critical_pattern_list": ["FATAL"],
-            "negpattern_list": [],
-            "critical_negpattern_list": ["IGNORE"],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        self.config["pattern_list"] = ["ERROR"]
+        self.config["critical_pattern_list"] = ["FATAL"]
+        self.config["critical_negpattern_list"] = ["IGNORE"]
+        log = LogChecker(self.config)
 
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: FATAL ERROR IGNORE\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
+        # check --pattern and --critical-negpattern
+        # Dec  5 12:34:50 hostname test: ERROR IGNORE
+        line1 = self._make_line(self._get_timestamp(), "test", "ERROR IGNORE")
+        self._write_logfile(self.logfile, line1)
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), "OK - No matches found.")
+        self.assertEqual(log.get_message(), self.MESSAGE_OK)
 
-    def test_critical_negpattern_with_pattern(self):
-        """--criticalpattern option
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": [],
-            "critical_pattern_list": ["FATAL"],
-            "negpattern_list": [],
-            "critical_negpattern_list": ["IGNORE"],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
-
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: IGNORE FATAL\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
+        # check --critical-pattern and --ciritical-negpattern
+        # Dec  5 12:34:50 hostname test: FATAL IGNORE
+        line2 = self._make_line(self._get_timestamp(), "test", "FATAL IGNORE")
+        self._write_logfile(self.logfile, line2)
+        log.clear_state()
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), "OK - No matches found.")
+        self.assertEqual(log.get_message(), self.MESSAGE_OK)
 
-    def test_critical_negpattern_with_pattern_and_criticalpattern(self):
-        """--criticalpattern option
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": ["FATAL"],
-            "negpattern_list": [],
-            "critical_negpattern_list": ["IGNORE"],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
-
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR IGNORE FATAL\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
+        # check --pattern, --critical-pattern and --critical-negpattern
+        # Dec  5 12:34:50 hostname test: ERROR FATAL IGNORE
+        line3 = self._make_line(
+            self._get_timestamp(), "test", "ERROR FATAL IGNORE")
+        self._write_logfile(self.logfile, line3)
+        log.clear_state()
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), "OK - No matches found.")
+        self.assertEqual(log.get_message(), self.MESSAGE_OK)
 
-    def test_negpattern_with_case_insensitive(self):
-        """--negpattern and --case-insensitive options
+    def test_case_insensitive(self):
+        """--case-insensitive option
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": ["ignore"],
-            "critical_negpattern_list": [],
-            "case_insensitive": True,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        self.config["pattern_list"] = ["error"]
+        self.config["critical_pattern_list"] = ["fatal"]
+        self.config["negpattern_list"] = ["ignore"]
+        self.config["case_insensitive"] = True
+        log = LogChecker(self.config)
 
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR IGNORE\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        log.check_log(self.logfile, self.seekfile)
-
-        self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), "OK - No matches found.")
-
-    def test_pattern_with_multiple_lines(self):
-        """--pattern options with multiples lines
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR1.*ERROR2"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": True,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
-
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR1\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR2\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
+        # check --pattern
+        # Dec  5 12:34:50 hostname test: ERROR
+        line1 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line1)
+        log.clear_state()
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR1 ERROR2 at {0}".format(self.logfile))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line1, self.logfile))
 
-    def test_negpattern_with_multiple_lines(self):
-        """--negpattern options with multiple lines
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": ["IGNORE"],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": True,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        # check --critical-pattern
+        # Dec  5 12:34:50 hostname test: FATAL
+        line2 = self._make_line(self._get_timestamp(), "test", "FATAL")
+        self._write_logfile(self.logfile, line2)
+        log.clear_state()
+        log.check_log(self.logfile, self.seekfile)
 
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR IGNORE\n")
-        fileobj.flush()
-        fileobj.close()
+        self.assertEqual(log.get_state(), LogChecker.STATE_CRITICAL)
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_CRITICAL_ONE.format(line2, self.logfile))
 
+        # check --pattern and --negpattern
+        # Dec  5 12:34:50 hostname test: ERROR ERROR IGNORE
+        line3 = self._make_line(self._get_timestamp(), "test", "ERROR IGNORE")
+        self._write_logfile(self.logfile, line3)
+        log.clear_state()
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), 'OK - No matches found.')
+        self.assertEqual(log.get_message(), self.MESSAGE_OK)
 
-    def test_logfile_with_wildcard(self):
-        """--logfile option with wild card '*'
+    def test_encoding(self):
+        """--pattern and --encoding
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        self.config["pattern_list"] = ["エラー"]
+        self.config["encoding"] = "EUC-JP"
+        log = LogChecker(self.config)
 
-        fileobj = open(self.logfile1, 'a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        time.sleep(1)
-
-        fileobj = open(self.logfile2, 'a')
-        fileobj.write("Dec  5 12:34:58 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:59 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:59 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=False)
+        # Dec  5 12:34:50 hostname test: エラー
+        line = self._make_line(self._get_timestamp(), "test", "エラー")
+        self._write_logfile(self.logfile, line, encoding='EUC-JP')
+        log.clear_state()
+        log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 2 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at {0},Dec  5 12:34:59 hostname test: ERROR at {1}".format(self.logfile1, self.logfile2))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line, self.logfile))
 
-    def test_logfile_with_filename(self):
-        """--logfile option with multiple filenames
+    def test_multiline(self):
+        """--multiline
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        self.config["pattern_list"] = ["ERROR1.*ERROR2"]
+        self.config["negpattern_list"] = ["IGNORE"]
+        self.config["multiline"] = True
+        log = LogChecker(self.config)
 
-        fileobj = open(self.logfile1, 'a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # check --pattern, --multiline
+        # Dec  5 12:34:50 hostname test: ERROR1
+        # Dec  5 12:34:50 hostname test: ERROR2
+        timestamp = self._get_timestamp()
+        lines = []
+        messages = ["ERROR1", "ERROR2"]
+        for message in messages:
+            lines.append(self._make_line(timestamp, "test", message))
+        self._write_logfile(self.logfile, lines)
+        log.clear_state()
+        log.check_log(self.logfile, self.seekfile)
 
-        time.sleep(1)
+        # detected line: Dec  5 12:34:50 hostname test: ERROR1 ERROR2
+        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(
+                lines[0] + " " + messages[1], self.logfile))
 
-        fileobj = open(self.logfile2, 'a')
-        fileobj.write("Dec  5 12:34:58 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:59 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:59 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # check --pattern, --negpattern and --multiline
+        # Dec  5 12:34:50 hostname test: ERROR
+        # Dec  5 12:34:50 hostname test: ERROR IGNORE
+        timestamp = self._get_timestamp()
+        lines = []
+        messages = ["ERROR", "ERROR IGNORE"]
+        for message in messages:
+            lines.append(self._make_line(timestamp, "test", message))
+        self._write_logfile(self.logfile, lines)
+        log.clear_state()
+        log.check_log(self.logfile, self.seekfile)
 
+        # detected line: Dec  5 12:34:50 hostname test: ERROR ERROR IGNORE
+        self.assertEqual(log.get_state(), LogChecker.STATE_OK)
+        self.assertEqual(log.get_message(), self.MESSAGE_OK)
+
+    def test_logfile(self):
+        """--logfile option
+        """
+        self.config["pattern_list"] = ["ERROR"]
+        log = LogChecker(self.config)
+
+        # check -logfile option with wild card '*'
+        # Dec  5 12:34:50 hostname test: ERROR
+        line1 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile1, line1)
+
+        # Dec  5 12:34:50 hostname test: ERROR
+        line2 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile2, line2)
+        log.clear_state()
+        log.check_log_multi(self.logfile_pattern, self.SEEKDIR)
+
+        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_TWO_IN_TWO_FILES.format(
+                line1, self.logfile1, line2, self.logfile2))
+
+        # --logfile option with multiple filenames
+        # Dec  5 12:34:50 hostname test: ERROR
+        line1 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile1, line1)
+
+        # Dec  5 12:34:50 hostname test: ERROR
+        line2 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile2, line2)
         logfile_pattern = "{0} {1}".format(self.logfile1, self.logfile2)
-        log.check_log_multi(logfile_pattern, self.seekdir, remove_seekfile=False)
-
-        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 2 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at {0},Dec  5 12:34:59 hostname test: ERROR at {1}".format(self.logfile1, self.logfile2))
-
-    def test_scantime_without_scantime(self):
-        """--scantime option without scantime.
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 2,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
-
-        fileobj = open(self.logfile1, 'a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        time.sleep(4)
-        log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=False)
-
-        self.assertEqual(log.get_state(), LogChecker.STATE_OK)
-        self.assertEqual(log.get_message(), 'OK - No matches found.')
-
-    def test_scantime_within_scantime(self):
-        """--scantime option within scantime.
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 2,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
-
-        fileobj = open(self.logfile1, 'a')
-        fileobj.write("Dec  5 12:34:58 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:59 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:59 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        # The first ERROR message should be older than scantime. Therefore, don't scan it.
-        log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=False)
-
-        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at {0}".format(self.logfile1))
-
-    def test_scantime_with_multiple_logfiles(self):
-        """--scantime option with multiple logfiles.
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 2,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
-
-        fileobj = open(self.logfile1, 'a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        time.sleep(4)
-
-        fileobj = open(self.logfile2, 'a')
-        fileobj.write("Dec  5 12:34:58 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:59 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:59 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        # logfile1 should be older than timespan. Therefore, don't scan it.
-        log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=False)
-
-        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at {0}".format(self.logfile2))
-
-    def test_remove_seekfile_without_expiration(self):
-        """--expiration and --remove-seekfile options
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 2,
-            "expiration": 3
-        }
-        log = LogChecker(initial_data)
-
-        fileobj = open(self.logfile1, 'a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=True)
         log.clear_state()
-        time.sleep(4)
-
-        fileobj = open(self.logfile2, 'a')
-        fileobj.write("Dec  5 12:34:58 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:59 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:59 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        # seek file of logfile1 should be purged.
-        log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=True)
+        log.check_log_multi(logfile_pattern, self.SEEKDIR)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at {0}".format(self.logfile2))
-        self.assertFalse(os.path.exists(self.seekfile1))
-        self.assertTrue(os.path.exists(self.seekfile2))
-
-    def test_remove_seekfile_within_expiration(self):
-        """--expiration and --remove-seekfile options
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 2,
-            "expiration": 10
-        }
-        log = LogChecker(initial_data)
-
-        fileobj = open(self.logfile1, 'a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=True)
-        log.clear_state()
-        time.sleep(4)
-
-        fileobj = open(self.logfile2, 'a')
-        fileobj.write("Dec  5 12:34:58 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:59 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:59 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        # seek file of logfile1 should be purged.
-        log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=True)
-
-        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at {0}".format(self.logfile2))
-        self.assertTrue(os.path.exists(self.seekfile1))
-        self.assertTrue(os.path.exists(self.seekfile2))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_TWO_IN_TWO_FILES.format(
+                line1, self.logfile1, line2, self.logfile2))
 
     def test_trace_inode(self):
         """--trace_inode
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": True,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        self.config["pattern_list"] = ["ERROR"]
+        self.config["trace_inode"] = True
+        log = LogChecker(self.config)
 
+        # within expiration
         # create logfile
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # Dec  5 12:34:50 hostname test: ERROR
+        line1 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line1)
 
         # create seekfile of logfile
-        log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=False)
-        log.clear_state()
+        log.check_log_multi(self.logfile_pattern, self.SEEKDIR)
         seekfile_1 = LogChecker.get_seekfile(
-            self.logfile_pattern, self.seekdir, self.logfile, trace_inode=True)
+            self.logfile_pattern, self.SEEKDIR, self.logfile, trace_inode=True)
 
         # update logfile
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:55 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:55 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # Dec  5 12:34:51 hostname test: ERROR
+        line2 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line2)
 
         # log rotation
         os.rename(self.logfile, self.logfile1)
 
         # create a new logfile
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:59 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # Dec  5 12:34:52 hostname noop: NOOP
+        line3 = self._make_line(self._get_timestamp(), "noop", "NOOP")
+        self._write_logfile(self.logfile, line3)
 
         # create seekfile of logfile
-        log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=False)
+        log.clear_state()
+        log.check_log_multi(self.logfile_pattern, self.SEEKDIR)
         seekfile_2 = LogChecker.get_seekfile(
-            self.logfile_pattern, self.seekdir, self.logfile, trace_inode=True)
+            self.logfile_pattern, self.SEEKDIR, self.logfile, trace_inode=True)
         seekfile1_2 = LogChecker.get_seekfile(
-            self.logfile_pattern, self.seekdir, self.logfile1, trace_inode=True)
+            self.logfile_pattern, self.SEEKDIR, self.logfile1,
+            trace_inode=True)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:55 hostname test: ERROR at {0}".format(self.logfile1))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line2, self.logfile1))
         self.assertEqual(seekfile_1, seekfile1_2)
         self.assertTrue(os.path.exists(seekfile_2))
         self.assertTrue(os.path.exists(seekfile1_2))
 
-    def test_trace_inode_without_expiration(self):
+    def test_scantime(self):
+        """--scantime option
+        """
+        self.config["pattern_list"] = ["ERROR"]
+        self.config["scantime"] = 2
+        log = LogChecker(self.config)
+
+        # within scantime.
+        # Dec  5 12:34:50 hostname test: ERROR
+        line1 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile1, line1)
+        log.clear_state()
+        log.check_log_multi(self.logfile_pattern, self.SEEKDIR)
+
+        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line1, self.logfile1))
+
+        # over scantime
+        # Dec  5 12:34:50 hostname test: ERROR
+        line2 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile1, line2)
+        time.sleep(4)
+        log.clear_state()
+        log.check_log_multi(self.logfile_pattern, self.SEEKDIR)
+
+        self.assertEqual(log.get_state(), LogChecker.STATE_OK)
+        self.assertEqual(log.get_message(), self.MESSAGE_OK)
+
+        # multiple logfiles.
+        # Dec  5 12:34:50 hostname test: ERROR
+        line3 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile1, line3)
+        time.sleep(4)
+
+        # Dec  5 12:34:54 hostname test: ERROR
+        line4 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile2, line4)
+
+        # logfile1 should be older than spantime. Therefore, don't scan it.
+        log.clear_state()
+        log.check_log_multi(self.logfile_pattern, self.SEEKDIR)
+
+        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line4, self.logfile2))
+
+    def test_remove_seekfile(self):
+        """--expiration and --remove-seekfile options
+        """
+        self.config["pattern_list"] = ["ERROR"]
+        self.config["scantime"] = 2
+        self.config["expiration"] = 4
+        log = LogChecker(self.config)
+
+        # within expiration
+        # Dec  5 12:34:50 hostname test: ERROR
+        line1 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile1, line1)
+
+        log.check_log_multi(
+            self.logfile_pattern, self.SEEKDIR, remove_seekfile=True)
+        time.sleep(2)
+
+        # Dec  5 12:34:54 hostname test: ERROR
+        line2 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile2, line2)
+
+        # seek file of logfile1 should not be purged.
+        log.clear_state()
+        log.check_log_multi(
+            self.logfile_pattern, self.SEEKDIR, remove_seekfile=True)
+
+        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line2, self.logfile2))
+        self.assertTrue(os.path.exists(self.seekfile1))
+        self.assertTrue(os.path.exists(self.seekfile2))
+
+        # over expiration
+        # Dec  5 12:34:50 hostname test: ERROR
+        line1 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile1, line1)
+
+        log.check_log_multi(
+            self.logfile_pattern, self.SEEKDIR, remove_seekfile=True)
+        time.sleep(6)
+
+        # Dec  5 12:34:54 hostname test: ERROR
+        line2 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile2, line2)
+
+        # seek file of logfile1 should be purged.
+        log.clear_state()
+        log.check_log_multi(
+            self.logfile_pattern, self.SEEKDIR, remove_seekfile=True)
+
+        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line2, self.logfile2))
+        self.assertFalse(os.path.exists(self.seekfile1))
+        self.assertTrue(os.path.exists(self.seekfile2))
+
+    def test_remove_seekfile_inode(self):
         """--trace_inode, --expiration and --remove-seekfile options
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": True,
-            "multiline": False,
-            "scantime": 2,
-            "expiration": 3
-        }
-        log = LogChecker(initial_data)
+        self.config["pattern_list"] = ["ERROR"]
+        self.config["trace_inode"] = True
+        self.config["scantime"] = 2
+        self.config["expiration"] = 3
+        log = LogChecker(self.config)
 
         # create logfile
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:50 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # Dec  5 12:34:50 hostname test: ERROR
+        line1 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line1)
 
         # log rotation
         os.rename(self.logfile, self.logfile1)
 
         # create new logfile
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:53 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:53 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:54 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # Dec  5 12:34:50 hostname test: ERROR
+        line2 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line2)
 
         # do check_log_multi, and create seekfile and seekfile1
-        log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=True)
         log.clear_state()
+        log.check_log_multi(
+            self.logfile_pattern, self.SEEKDIR, remove_seekfile=True)
         seekfile_1 = LogChecker.get_seekfile(
-            self.logfile_pattern, self.seekdir, self.logfile, trace_inode=True)
+            self.logfile_pattern, self.SEEKDIR, self.logfile,
+            trace_inode=True)
         seekfile1_1 = LogChecker.get_seekfile(
-            self.logfile_pattern, self.seekdir, self.logfile1, trace_inode=True)
+            self.logfile_pattern, self.SEEKDIR, self.logfile1,
+            trace_inode=True)
         time.sleep(4)
 
         # update logfile
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:58 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:59 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:59 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # Dec  5 12:34:54 hostname test: ERROR
+        line3 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line3)
 
         # log rotation, purge old logfile2
         os.rename(self.logfile1, self.logfile2)
         os.rename(self.logfile, self.logfile1)
 
         # seek file of old logfile1 should be purged.
-        log.check_log_multi(self.logfile_pattern, self.seekdir, remove_seekfile=True)
+        log.clear_state()
+        log.check_log_multi(
+            self.logfile_pattern, self.SEEKDIR, remove_seekfile=True)
         seekfile1_2 = LogChecker.get_seekfile(
-            self.logfile_pattern, self.seekdir, self.logfile1, trace_inode=True)
+            self.logfile_pattern, self.SEEKDIR, self.logfile1,
+            trace_inode=True)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:59 hostname test: ERROR at {0}".format(self.logfile1))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line3, self.logfile1))
         self.assertEqual(seekfile_1, seekfile1_2)
         self.assertFalse(os.path.exists(seekfile1_1))
         self.assertTrue(os.path.exists(seekfile1_2))
@@ -1039,365 +632,307 @@ class TestSequenceFunctions(unittest.TestCase):
     def test_replace_pipe_symbol(self):
         """replace pipe symbol
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        line = "Dec | 5 12:34:56 hostname test: ERROR"
+        self.config["pattern_list"] = ["ERROR"]
+        log = LogChecker(self.config)
 
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec | 5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec | 5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec | 5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
+        # Dec  5 12:34:50 hostname test: ERROR |
+        line = self._make_line(self._get_timestamp(), "test", "ERROR |")
+        self._write_logfile(self.logfile, line)
         log.check_log(self.logfile, self.seekfile)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec (pipe) 5 12:34:56 hostname test: ERROR at {0}".format(self.logfile))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(
+                line.replace("|", "(pipe)"), self.logfile))
 
     def test_seekfile_tag(self):
         """--seekfile-tag
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200
-        }
-        log = LogChecker(initial_data)
+        self.config["pattern_list"] = ["ERROR"]
+        log = LogChecker(self.config)
 
         # create new logfiles
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # Dec  5 12:34:50 hostname test: ERROR
+        line1 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line1)
 
-        fileobj = open(self.logfile1, 'a')
-        fileobj.write("Dec  5 12:34:56 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:56 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:57 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # Dec  5 12:34:50 hostname test: ERROR
+        line2 = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile1, line2)
 
-        fileobj = open(self.logfile2, 'a')
-        fileobj.write("Dec  5 12:34:58 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:59 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # Dec  5 12:34:50 hostname test: ERROR
+        line3 = self._make_line(self._get_timestamp(), "noop", "NOOP")
+        self._write_logfile(self.logfile2, line3)
 
         # create seekfile of logfile
         seekfile_1 = LogChecker.get_seekfile(
-            self.logfile_pattern, self.seekdir, self.logfile, seekfile_tag=self.tag1)
+            self.logfile_pattern, self.SEEKDIR, self.logfile,
+            seekfile_tag=self.tag1)
         seekfile_2 = LogChecker.get_seekfile(
-            self.logfile_pattern, self.seekdir, self.logfile, seekfile_tag=self.tag1)
+            self.logfile_pattern, self.SEEKDIR, self.logfile,
+            seekfile_tag=self.tag1)
         seekfile_3 = LogChecker.get_seekfile(
-            self.logfile_pattern, self.seekdir, self.logfile, seekfile_tag=self.tag2)
+            self.logfile_pattern, self.SEEKDIR, self.logfile,
+            seekfile_tag=self.tag2)
         log.check_log(self.logfile, seekfile_3)
         log.clear_state()
-        log.check_log_multi(self.logfile_pattern, self.seekdir, seekfile_tag=self.tag2)
+        log.check_log_multi(
+            self.logfile_pattern, self.SEEKDIR, seekfile_tag=self.tag2)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:56 hostname test: ERROR at {0}".format(self.logfile1))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line2, self.logfile1))
         self.assertEqual(seekfile_1, seekfile_2)
         self.assertNotEqual(seekfile_1, seekfile_3)
         self.assertTrue(seekfile_1.find(self.tag1))
         self.assertTrue(os.path.exists(seekfile_3))
 
-    def test_check_without_cache(self):
+    def test_check(self):
         """LogChecker.check()
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200,
-            "cache": False,
-            "cachetime": 60
-        }
-        log = LogChecker(initial_data)
+        self.config["pattern_list"] = ["ERROR"]
+        log = LogChecker(self.config)
 
-        # create new logfiles
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # Dec  5 12:34:50 hostname test: ERROR
+        line = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line)
 
-        log.check(self.logfile, '', self.seekdir)
+        # check
+        log.clear_state()
+        log.check(self.logfile, '', self.SEEKDIR)
 
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at {0}".format(self.logfile))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line, self.logfile))
 
+        # check again
         log.clear_state()
-        log.check(self.logfile, '', self.seekdir)
+        log.check(self.logfile, '', self.SEEKDIR)
+
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
 
-    def test_check_with_cache(self):
-        """--cache --cachetime=60
+    def test_cache(self):
+        """--cache
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200,
-            "cache": True,
-            "cachetime": 60
-        }
-        log = LogChecker(initial_data)
+        self.config["pattern_list"] = ["ERROR"]
+        self.config["cache"] = True
+        self.config["cachetime"] = 2
+        log = LogChecker(self.config)
 
-        # create new logfiles
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # within cachetime
+        # Dec  5 12:34:50 hostname test: ERROR
+        line = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line)
 
-        log.check(self.logfile, '', self.seekdir)
+        # check
+        log.clear_state()
+        log.check(self.logfile, '', self.SEEKDIR)
+
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at {0}".format(self.logfile))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line, self.logfile))
+
+        # check again
+        log.clear_state()
+        log.check(self.logfile, '', self.SEEKDIR)
+
+        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line, self.logfile))
+
+        os.unlink(self.cachefile)
+
+        # over cachetime
+        # Dec  5 12:34:50 hostname test: ERROR
+        line = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line)
 
         log.clear_state()
-        log.check(self.logfile, '', self.seekdir)
+        log.check(self.logfile, '', self.SEEKDIR)
+
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at {0}".format(self.logfile))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line, self.logfile))
 
-    def test_check_with_expired_cache(self):
-        """--cache --cachetime=1
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200,
-            "cache": True,
-            "cachetime": 1
-        }
-        log = LogChecker(initial_data)
-
-        # create new logfiles
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        log.check(self.logfile, '', self.seekdir)
-        self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at {0}".format(self.logfile))
-
+        # check again
+        time.sleep(self.config["cachetime"] + 1)
         log.clear_state()
-        time.sleep(2)
-        log.check(self.logfile, '', self.seekdir)
+        log.check(self.logfile, '', self.SEEKDIR)
+
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
+
+        os.unlink(self.cachefile)
 
     def test_lock_timeout(self):
-        """--lock-timeout with lock timeout
+        """--lock-timeout
         """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200,
-            "cache": False,
-            "cachetime": 60,
-            "lock_timeout": 1
-        }
-        log = LogChecker(initial_data)
+        self.config["pattern_list"] = ["ERROR"]
+        self.config["lock_timeout"] = 4
+        log = LogChecker(self.config)
 
-        # create new logfiles
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
+        # within lock_timeout
+        # Dec  5 12:34:50 hostname test: ERROR
+        line = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line)
 
-        prefix_datafile = LogChecker.get_prefix_datafile('', self.seekdir)
-        lockfile = "".join([prefix_datafile, LogChecker.SUFFIX_LOCK])
-        code = """import time
-from check_log_ng import LogChecker
-lockfile = '{0}'
-lockfileobj = LogChecker.lock(lockfile)
-time.sleep(5)
-LogChecker.unlock(lockfile, lockfileobj)
-""".format(lockfile)
-        code = code.replace("\n", ";")
-        proc = subprocess.Popen(['python', '-c', code])
-        time.sleep(2)
-        log.check(self.logfile, '', self.seekdir)
+        # locked by an another process
+        proc = self._run_locked_subprocess(2)
+        time.sleep(1)
+
+        # check
+        log.clear_state()
+        log.check(self.logfile, '', self.SEEKDIR)
         proc.wait()
-        self.assertEqual(log.get_state(), LogChecker.STATE_UNKNOWN)
-        self.assertEqual(log.get_message(), "UNKNOWN: Lock timeout. Another process is running.")
 
-    def test_lock_timeout_without_timeout(self):
-        """--lock-timeout without timeout
-        """
-        initial_data = {
-            "logformat": self.logformat_syslog,
-            "pattern_list": ["ERROR"],
-            "critical_pattern_list": [],
-            "negpattern_list": [],
-            "critical_negpattern_list": [],
-            "case_insensitive": False,
-            "warning": 1,
-            "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
-            "trace_inode": False,
-            "multiline": False,
-            "scantime": 86400,
-            "expiration": 691200,
-            "cache": False,
-            "cachetime": 60,
-            "lock_timeout": 5
-        }
-        log = LogChecker(initial_data)
-
-        # create new logfiles
-        fileobj = io.open(self.logfile, mode='a')
-        fileobj.write("Dec  5 12:34:51 hostname noop: NOOP\n")
-        fileobj.write("Dec  5 12:34:51 hostname test: ERROR\n")
-        fileobj.write("Dec  5 12:34:52 hostname noop: NOOP\n")
-        fileobj.flush()
-        fileobj.close()
-
-        prefix_datafile = LogChecker.get_prefix_datafile('', self.seekdir)
-        lockfile = "".join([prefix_datafile, LogChecker.SUFFIX_LOCK])
-        code = """import time
-from check_log_ng import LogChecker
-lockfile = '{0}'
-lockfileobj = LogChecker.lock(lockfile)
-time.sleep(3)
-LogChecker.unlock(lockfile, lockfileobj)
-""".format(lockfile)
-        code = code.replace("\n", ";")
-        proc = subprocess.Popen(['python', '-c', code])
-        time.sleep(2)
-        log.check(self.logfile, '', self.seekdir)
-        proc.wait()
         self.assertEqual(log.get_state(), LogChecker.STATE_WARNING)
-        self.assertEqual(log.get_message(), "WARNING: Found 1 lines (limit=1/0): Dec  5 12:34:51 hostname test: ERROR at {0}".format(self.logfile))
+        self.assertEqual(
+            log.get_message(),
+            self.MESSAGE_WARNING_ONE.format(line, self.logfile))
+
+        # over lock_timeout
+        # Dec  5 12:34:50 hostname test: ERROR
+        line = self._make_line(self._get_timestamp(), "test", "ERROR")
+        self._write_logfile(self.logfile, line)
+
+        # locked by an another process
+        proc = self._run_locked_subprocess(6)
+        time.sleep(1)
+
+        # check
+        log.clear_state()
+        log.check(self.logfile, '', self.SEEKDIR)
+        proc.wait()
+
+        self.assertEqual(log.get_state(), LogChecker.STATE_UNKNOWN)
+        self.assertEqual(log.get_message(), self.MESSAGE_UNKNOWN_LOCK_TIMEOUT)
 
     def test_get_prefix_datafile(self):
         """LogChecker.get_prefix_datafile()
         """
         prefix_datafile = LogChecker.get_prefix_datafile(self.seekfile, '', '')
-        self.assertEqual(prefix_datafile, os.path.join(os.path.dirname(self.seekfile), LogChecker.PREFIX_DATA))
+        self.assertEqual(
+            prefix_datafile,
+            os.path.join(
+                os.path.dirname(self.seekfile), LogChecker.PREFIX_DATA))
 
-        prefix_datafile = LogChecker.get_prefix_datafile('', self.seekdir, '')
-        self.assertEqual(prefix_datafile, os.path.join(self.seekdir, LogChecker.PREFIX_DATA))
+        prefix_datafile = LogChecker.get_prefix_datafile('', self.SEEKDIR, '')
+        self.assertEqual(
+            prefix_datafile,
+            os.path.join(self.SEEKDIR, LogChecker.PREFIX_DATA))
 
-        prefix_datafile = LogChecker.get_prefix_datafile(self.seekfile, self.seekdir, self.tag1)
-        self.assertEqual(prefix_datafile, os.path.join(self.seekdir, "".join([LogChecker.PREFIX_DATA, '.', self.tag1])))
+        prefix_datafile = LogChecker.get_prefix_datafile(
+            self.seekfile, self.SEEKDIR, self.tag1)
+        self.assertEqual(
+            prefix_datafile,
+            os.path.join(self.SEEKDIR,
+                         "{0}.{1}".format(LogChecker.PREFIX_DATA, self.tag1)))
 
     def test_lock(self):
         """LogChecker.lock()
         """
-        prefix_datafile = LogChecker.get_prefix_datafile('', self.seekdir)
-        lockfile = "".join([prefix_datafile, LogChecker.SUFFIX_LOCK])
-        lockfileobj = LogChecker.lock(lockfile)
+        # lock succeeded
+        lockfileobj = LogChecker.lock(self.lockfile)
         self.assertNotEqual(lockfileobj, None)
-        LogChecker.unlock(lockfile, lockfileobj)
+        LogChecker.unlock(self.lockfile, lockfileobj)
 
-    def test_lock_with_timeout(self):
-        """LogChecker.lock() with timeout.
-        """
-        prefix_datafile = LogChecker.get_prefix_datafile('', self.seekdir)
-        lockfile = "".join([prefix_datafile, LogChecker.SUFFIX_LOCK])
-        code = """import time
-from check_log_ng import LogChecker
-lockfile = '{0}'
-lockfileobj = LogChecker.lock(lockfile)
-time.sleep(4)
-LogChecker.unlock(lockfile, lockfileobj)
-""".format(lockfile)
-        code = code.replace("\n", ";")
-        proc = subprocess.Popen(['python', '-c', code])
-        time.sleep(2)
+        # lock failed
+        # locked by an another process
+        proc = self._run_locked_subprocess(3)
+        time.sleep(1)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            lockfileobj = LogChecker.lock(lockfile)
+            lockfileobj = LogChecker.lock(self.lockfile)
         proc.wait()
         self.assertEqual(lockfileobj, None)
 
     def test_unlock(self):
         """LogChecker.unlock()
         """
-        prefix_datafile = LogChecker.get_prefix_datafile('', self.seekdir)
-        lockfile = "".join([prefix_datafile, LogChecker.SUFFIX_LOCK])
-        lockfileobj = LogChecker.lock(lockfile)
-        LogChecker.unlock(lockfile, lockfileobj)
-        self.assertFalse(os.path.exists(lockfile))
+        lockfileobj = LogChecker.lock(self.lockfile)
+        LogChecker.unlock(self.lockfile, lockfileobj)
+        self.assertFalse(os.path.exists(self.lockfile))
         self.assertTrue(lockfileobj.closed)
+
+    def _get_timestamp(self):
+        # format: Dec  5 12:34:00
+        timestamp = LogChecker.to_unicode(
+            datetime.datetime.now().strftime("%b %e %T"))
+        return timestamp
+
+    def _get_customized_timestamp(self):
+        # format: Thu Dec 05 12:34:56 2013
+        timestamp = LogChecker.to_unicode(
+            datetime.datetime.now().strftime("%a %b %d %T %Y"))
+        return timestamp
+
+    def _make_line(self, timestamp, tag, message):
+        # format: Dec  5 12:34:00 hostname noop: NOOP
+        line = "{0} hostname {1}: {2}".format(timestamp, tag, message)
+        return line
+
+    def _make_customized_line(self, timestamp, level, message):
+        # format: [Thu Dec 05 12:34:56 2013] [info] NOOP
+        line = "[{0}] [{1}] {2}".format(timestamp, level, message)
+        return line
+
+    def _write_logfile(self, logfile, lines, encoding='utf-8'):
+        """Write log file for syslog format."""
+        fileobj = io.open(logfile, mode='a', encoding=encoding)
+        fileobj.write(self._make_line(self._get_timestamp(), "noop", "NOOP"))
+        fileobj.write("\n")
+        if isinstance(lines, list):
+            for line in lines:
+                fileobj.write(line)
+                fileobj.write("\n")
+        else:
+            fileobj.write(lines)
+            fileobj.write("\n")
+        fileobj.write(self._make_line(self._get_timestamp(), "noop", "NOOP"))
+        fileobj.write("\n")
+        fileobj.flush()
+        fileobj.close()
+
+    def _write_customized_logfile(self, logfile, lines, encoding='utf-8'):
+        """Write log file for customized format."""
+        fileobj = io.open(logfile, mode='a', encoding=encoding)
+        fileobj.write(
+            self._make_customized_line(
+                self._get_customized_timestamp(), "info", "NOOP"))
+        fileobj.write("\n")
+        if isinstance(lines, list):
+            for line in lines:
+                fileobj.write(line)
+                fileobj.write("\n")
+        else:
+            fileobj.write(lines)
+            fileobj.write("\n")
+        fileobj.write(
+            self._make_customized_line(
+                self._get_customized_timestamp(), "info", "NOOP"))
+        fileobj.write("\n")
+        fileobj.flush()
+        fileobj.close()
+
+    def _run_locked_subprocess(self, sleeptime):
+        code = (
+            "import time\n"
+            "from check_log_ng import LogChecker\n"
+            "lockfile = '{0}'\n"
+            "lockfileobj = LogChecker.lock(lockfile)\n"
+            "time.sleep({1})\n"
+            "LogChecker.unlock(lockfile, lockfileobj)\n"
+        ).format(self.lockfile, LogChecker.to_unicode(str(sleeptime)))
+        code = code.replace("\n", ";")
+        proc = subprocess.Popen(['python', '-c', code])
+        return proc
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Add python 3.5 and 3.6 support
- Remove python 2.5 or lower support.
- Replace optparse module with argparse module.
    - On python 2.6, require argparse module.
- Remove `--debug` option. Instead, use `-O` option of python.
- Fix pylint warnings.
- Unify `_find_pattern()`, `_find_critical_pattern()`, `_check_negpattern()` and `_check_critical_negpattern()` into `_find_pattern()`
- On `_check_parser_args()`, remove unused conditions.
- Refactor the unit test.