### PR TITLE
Remove --cache option from the document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,6 @@ optional arguments:
                         Remove expired seek files. See also --expiration.
   -M, --multiline       Consider multiple lines with same key as one log
                         output. See also --format.
-  --cache               Cache the result for the period specified by the
-                        option --cachetime. Since the caching feature is
-                        enabled by default, you do not need to set this option
-                        to use it. If you want to disable it, set '--
-                        cachetime=0'. This option is for backwards
-                        compatibility.
   --cachetime <seconds>
                         The period to cache the result. If you want to disable
                         this cache feature, set '0'. (default: 60)


### PR DESCRIPTION
In relation to #24, this pull request removes `--cache` option from the document.
