### PR TITLE
Remove options `--nodiff-warn` and `--nodiff-crit` which are not impl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,6 @@ optional arguments:
                         Return CRITICAL if at least this many matches found.
                         i.e. don't return critical alerts unless specified
                         explicitly. (default: 0)
-  -d, --nodiff-warn     Return WARNING if the log file was not written to
-                        since the last scan. (not implemented)
-  -D, --nodiff-crit     Return CRITICAL if the log was not written to since
-                        the last scan. (not impremented)
   -t <seconds>, --scantime <seconds>
                         The range of time to scan. The log files older than
                         this time are not scanned. (default: 86400)

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -1010,8 +1010,6 @@ def _generate_config(args):
         "encoding": args.encoding,
         "warning": args.warning,
         "critical": args.critical,
-        "nodiff_warn": args.nodiff_warn,
-        "nodiff_crit": args.nodiff_crit,
         "trace_inode": args.trace_inode,
         "multiline": args.multiline,
         "scantime": args.scantime,

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -859,24 +859,6 @@ def _make_parser():
               " (default: %(default)s)")
     )
     parser.add_argument(
-        "-d", "--nodiff-warn",
-        action="store_true",
-        dest="nodiff_warn",
-        default=False,
-        help=("Return WARNING "
-              "if the log file was not written to since the last scan."
-              " (not implemented)")
-    )
-    parser.add_argument(
-        "-D", "--nodiff-crit",
-        action="store_true",
-        dest="nodiff_crit",
-        default=False,
-        help=("Return CRITICAL "
-              "if the log was not written to since the last scan."
-              " (not impremented)")
-    )
-    parser.add_argument(
         "-t", "--scantime",
         action="store",
         type=int,

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -75,8 +75,6 @@ class LogChecker(object):
         self.config['encoding'] = 'utf-8'
         self.config['warning'] = 1
         self.config['critical'] = 0
-        self.config['nodiff_warn'] = False
-        self.config['nodiff_crit'] = False
         self.config['trace_inode'] = False
         self.config['multiline'] = False
         self.config['scantime'] = 86400

--- a/test_check_log_ng.py
+++ b/test_check_log_ng.py
@@ -91,8 +91,6 @@ class LogCheckerTestCase(unittest.TestCase):
             "encoding": "utf-8",
             "warning": 1,
             "critical": 0,
-            "nodiff_warn": False,
-            "nodiff_crit": False,
             "trace_inode": False,
             "multiline": False,
             "scantime": 86400,


### PR DESCRIPTION
This pull request removes options `--nodiff-warn` and `--nodiff-crit` which are not implemented.
Because we does not have any plans to implement these features.


