### PR TITLE
add fallback path

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ If you use RHEL6/CentOS6, you can run:
 $ sudo yum install python-argparse
 ~~~
 
+Note:  By default, `FALLBACK_PATH` is set HEARTBEATS (it's us!) specific value.
+When you want to use `check_log_ng` with Python2.6 and use `FALLBACK_PATH`,
+change this to adjust to your environment.
+
 ## Usage
 
 ### Help

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -35,7 +35,19 @@ import hashlib
 import base64
 import fcntl
 import warnings
-import argparse
+
+FALLBACK_PATH = "/usr/local/hb-agent/bin"
+
+try:
+    import argparse
+except ImportError as _ex:
+    if __name__ != "__main__":
+        raise _ex
+    if FALLBACK_PATH not in os.environ["PATH"]:
+        os.environ["PATH"] = ":".join([FALLBACK_PATH, os.environ["PATH"]])
+        os.execve(__file__, sys.argv, os.environ)
+    else:
+        raise _ex
 
 # Globals
 __version__ = '2.0.3'


### PR DESCRIPTION
In CentOS6, system python is 2.6

With Python2.6, need to install argparse with pip or yum,
but `python-argparse` installed since CentOS6.7.

I think it's better that monitoring script has no dependency with os system.
So I added fallback `PATH` and add the way to use another python without modifying PATH Environment variables.