### PR TITLE
Fix issues where errors occur in the ASCII locale.

### DIFF
--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -700,14 +700,7 @@ class LogChecker(object):
         """
         pattern_list = []
         if pattern_string:
-            # Revert the surrogate-escaped string in the ASCII locale.
-            pattern_string = re.sub(
-                r'[\udc80-\udcff]+',
-                lambda m: b''.join(
-                    [bytes.fromhex('%x' % (ord(char) - ord('\udc00'))) for char in m.group(0)]
-                ).decode('utf-8'),
-                pattern_string)
-            pattern_list.append(LogChecker.to_unicode(pattern_string))
+            pattern_list.append(pattern_string)
         if pattern_filename:
             if os.path.isfile(pattern_filename):
                 lines = []
@@ -842,21 +835,13 @@ class LogChecker(object):
 
         """
         if sys.version_info >= (3,):
-            # Python3
-            # type: str or bytes
             if isinstance(string, bytes):
-                # type: bytes
                 # convert bytes to str.
                 return string.decode('utf-8')
-            # type: str
         else:
-            # Python2
-            # type: unicode or str
             if isinstance(string, str):
-                # type: str
                 # convert str to unicode.
                 return string.decode('utf-8')
-            # type: unicode
         return string
 
     @staticmethod
@@ -864,39 +849,26 @@ class LogChecker(object):
         """Convert str to bytes.
 
         Args:
-            string (str or unicode): The string to convert to bytes.
+            string (str): The string to convert to bytes.
 
         Returns:
             The bytes to be converted.
 
         """
         if sys.version_info >= (3,):
-            # Python3
-            # type: str or bytes
             if isinstance(string, str):
-                # type: str
+                # convert str to bytes.
                 return string.encode('utf-8')
-            # type: bytes
         else:
-            # Python2
-            # type: unicode or str
             if not isinstance(string, str):
-                # type: unicode
+                # convert unicode to str.
                 return string.encode('utf-8')
-            # type: str
         return string
 
 
 def _debug(string):
     if not __debug__:
         print("DEBUG: {0}".format(string))
-
-
-def _print_message(string):
-    with io.open(sys.stdout.fileno(), mode='w', encoding='utf-8') as fileobj:
-        fileobj.write(string)
-        fileobj.write('\n')
-        fileobj.close()
 
 
 def _make_parser():
@@ -1239,8 +1211,7 @@ def main():
         args.logfile_pattern, seekfile=args.seekfile,
         remove_seekfile=args.remove_seekfile, tag=args.tag)
     state = log.get_state()
-    message = log.get_message()
-    _print_message(message)
+    print(log.get_message())
     sys.exit(state)
 
 

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -700,7 +700,14 @@ class LogChecker(object):
         """
         pattern_list = []
         if pattern_string:
-            pattern_list.append(pattern_string)
+            # Revert the surrogate-escaped string in the ASCII locale.
+            pattern_string = re.sub(
+                r'[\udc80-\udcff]+',
+                lambda m: b''.join(
+                    [bytes.fromhex('%x' % (ord(char) - ord('\udc00'))) for char in m.group(0)]
+                ).decode('utf-8'),
+                pattern_string)
+            pattern_list.append(LogChecker.to_unicode(pattern_string))
         if pattern_filename:
             if os.path.isfile(pattern_filename):
                 lines = []
@@ -835,13 +842,21 @@ class LogChecker(object):
 
         """
         if sys.version_info >= (3,):
+            # Python3
+            # type: str or bytes
             if isinstance(string, bytes):
+                # type: bytes
                 # convert bytes to str.
                 return string.decode('utf-8')
+            # type: str
         else:
+            # Python2
+            # type: unicode or str
             if isinstance(string, str):
+                # type: str
                 # convert str to unicode.
                 return string.decode('utf-8')
+            # type: unicode
         return string
 
     @staticmethod
@@ -849,26 +864,39 @@ class LogChecker(object):
         """Convert str to bytes.
 
         Args:
-            string (str): The string to convert to bytes.
+            string (str or unicode): The string to convert to bytes.
 
         Returns:
             The bytes to be converted.
 
         """
         if sys.version_info >= (3,):
+            # Python3
+            # type: str or bytes
             if isinstance(string, str):
-                # convert str to bytes.
+                # type: str
                 return string.encode('utf-8')
+            # type: bytes
         else:
+            # Python2
+            # type: unicode or str
             if not isinstance(string, str):
-                # convert unicode to str.
+                # type: unicode
                 return string.encode('utf-8')
+            # type: str
         return string
 
 
 def _debug(string):
     if not __debug__:
         print("DEBUG: {0}".format(string))
+
+
+def _print_message(string):
+    with io.open(sys.stdout.fileno(), mode='w', encoding='utf-8') as fileobj:
+        fileobj.write(string)
+        fileobj.write('\n')
+        fileobj.close()
 
 
 def _make_parser():
@@ -1211,7 +1239,8 @@ def main():
         args.logfile_pattern, seekfile=args.seekfile,
         remove_seekfile=args.remove_seekfile, tag=args.tag)
     state = log.get_state()
-    print(log.get_message())
+    message = log.get_message()
+    _print_message(message)
     sys.exit(state)
 
 


### PR DESCRIPTION
This pull request fixes the following two issues.

In the ASCII locale, an error occurs when outputting the message.

```
# LANG=C python /vagrant/check_log_ng.py -l '/var/log/messages' -S /var/spool/check_log_ng -p 'エラー' --encoding=euc-jp 
Traceback (most recent call last):
  File "/vagrant/check_log_ng.py", line 1219, in <module>
    main()
  File "/vagrant/check_log_ng.py", line 1214, in main
    print(log.get_message())
UnicodeEncodeError: 'ascii' codec can't encode characters in position 65-67: ordinal not in range(128)
```

This pull request solves the issue by replacing `print()` with `_print_message()` which outputs an result message in UTF-8 encoding.


In python 3 and the ASCII locale, an error occurs if there are non-ASCII characters on the command-line pattern string.

```
# LANG=C python /vagrant/check_log_ng.py -l '/var/log/messages' -S /var/spool/check_log_ng -p 'エラー' --cachetime=0
<snip>
  File "/vagrant/check_log_ng.py", line 428, in _create_digest_condition
    digest_condition = LogChecker.get_digest('\n'.join(strings))
  File "/vagrant/check_log_ng.py", line 805, in get_digest
    hashobj.update(LogChecker.to_bytes(string))
  File "/vagrant/check_log_ng.py", line 871, in to_bytes
    return string.encode('utf-8')
UnicodeEncodeError: 'utf-8' codec can't encode character '\udce3' in position 236: surrogates not allowed
```

This pull request solves the issue by reverting a surrogate-escaped string in the ASCII locale.

Furthermore, it adds comments to `to_unicode()` and `to_bytes()` to make it easier to understand these processes.
