### PR TITLE
change message and state when logfile is not found

### DIFF
--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -615,7 +615,7 @@ class LogChecker(object):
         if not os.path.exists(logfile):
             # if set error_logfile_not_exist, return UNKNOWN.
             if self.config['error_logfile_not_exist']:
-                self.message = "UNKNOWN: {0} is not exist.".format(logfile)
+                self.message = "UNKNOWN: {0} does not exist.".format(logfile)
                 self.state = LogChecker.STATE_UNKNOWN
             return
 
@@ -703,7 +703,7 @@ class LogChecker(object):
 
         # if set error_logfile_not_exist, return UNKNOWN.
         if self.config['error_logfile_not_exist'] and len(logfile_list) == 0:
-            self.message = "UNKNOWN: {0} is not exist.".format(logfile_pattern)
+            self.message = "UNKNOWN: {0} does not exist.".format(logfile_pattern)
             self.state = LogChecker.STATE_UNKNOWN
         return
 

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -686,12 +686,10 @@ class LogChecker(object):
                 to prevent names collisions.
 
         """
-        log_exist = False
         logfile_list = self._get_logfile_list(logfile_pattern)
         for logfile in logfile_list:
             if not os.path.isfile(logfile):
                 continue
-            log_exist = True
             seekfile = self._create_seek_filename(
                 logfile_pattern, logfile,
                 trace_inode=self.config['trace_inode'], tag=tag)
@@ -704,7 +702,7 @@ class LogChecker(object):
                 self._remove_old_seekfile(logfile_pattern, tag)
 
         # if set error_no_exist, return UNKNOWN.
-        if self.config['error_no_exist'] and log_exist == False:
+        if self.config['error_no_exist'] and len(logfile_list) == 0:
             self.message = "UNKNOWN: {0} is not found.".format(logfile_pattern)
             self.state = LogChecker.STATE_UNKNOWN
         return

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -613,6 +613,8 @@ class LogChecker(object):
         _debug("logfile='{0}', seekfile='{1}'".format(logfile, seekfile))
         logfile = LogChecker.to_unicode(logfile)
         if not os.path.exists(logfile):
+            self.message = "UNKNOWN: Logfile is not found."
+            self.state = LogChecker.STATE_UNKNOWN
             return
 
         filesize = os.path.getsize(logfile)
@@ -682,10 +684,12 @@ class LogChecker(object):
                 to prevent names collisions.
 
         """
+        log_exist = False
         logfile_list = self._get_logfile_list(logfile_pattern)
         for logfile in logfile_list:
             if not os.path.isfile(logfile):
                 continue
+            log_exist = True
             seekfile = self._create_seek_filename(
                 logfile_pattern, logfile,
                 trace_inode=self.config['trace_inode'], tag=tag)
@@ -696,6 +700,9 @@ class LogChecker(object):
                 self._remove_old_seekfile_with_inode(logfile_pattern, tag)
             else:
                 self._remove_old_seekfile(logfile_pattern, tag)
+        if log_exist == False:
+            self.message = "UNKNOWN: Logfile is not found."
+            self.state = LogChecker.STATE_UNKNOWN
         return
 
     def clear_state(self):

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -615,7 +615,7 @@ class LogChecker(object):
         if not os.path.exists(logfile):
             # if set error_no_exist, return UNKNOWN.
             if self.config['error_no_exist']:
-                self.message = "UNKNOWN: Logfile is not found."
+                self.message = "UNKNOWN: {0} is not found.".format(logfile)
                 self.state = LogChecker.STATE_UNKNOWN
             return
 
@@ -705,7 +705,7 @@ class LogChecker(object):
 
         # if set error_no_exist, return UNKNOWN.
         if self.config['error_no_exist'] and log_exist == False:
-            self.message = "UNKNOWN: Logfile is not found."
+            self.message = "UNKNOWN: {0} is not found.".format(logfile_pattern)
             self.state = LogChecker.STATE_UNKNOWN
         return
 

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -146,7 +146,7 @@ class LogChecker(object):
         self.config['lock_timeout'] = 3
         self.config['output_header'] = False
         self.config['output_quiet'] = False
-        self.config['error_no_exist'] = False
+        self.config['error_logfile_not_exist'] = False
 
         # overwrite values with user's values
         for key in self.config:
@@ -613,8 +613,8 @@ class LogChecker(object):
         _debug("logfile='{0}', seekfile='{1}'".format(logfile, seekfile))
         logfile = LogChecker.to_unicode(logfile)
         if not os.path.exists(logfile):
-            # if set error_no_exist, return UNKNOWN.
-            if self.config['error_no_exist']:
+            # if set error_logfile_not_exist, return UNKNOWN.
+            if self.config['error_logfile_not_exist']:
                 self.message = "UNKNOWN: {0} is not found.".format(logfile)
                 self.state = LogChecker.STATE_UNKNOWN
             return
@@ -701,8 +701,8 @@ class LogChecker(object):
             else:
                 self._remove_old_seekfile(logfile_pattern, tag)
 
-        # if set error_no_exist, return UNKNOWN.
-        if self.config['error_no_exist'] and len(logfile_list) == 0:
+        # if set error_logfile_not_exist, return UNKNOWN.
+        if self.config['error_logfile_not_exist'] and len(logfile_list) == 0:
             self.message = "UNKNOWN: {0} is not found.".format(logfile_pattern)
             self.state = LogChecker.STATE_UNKNOWN
         return
@@ -1282,11 +1282,11 @@ def _make_parser():
         help=("QUIET mode: Suppress the output of matched lines.")
     )
     parser.add_argument(
-        "--error-no-exist",
+        "--error-logfile-not-exist",
         action="store_true",
-        dest="error_no_exist",
+        dest="error_logfile_not_exist",
         default=False,
-        help=("If file not exist, return UNKNOWN error.")
+        help=("Return UNKNOWN if the log file does not exist.")
     )
     return parser
 
@@ -1389,7 +1389,7 @@ def _generate_config(args):
         "lock_timeout": args.lock_timeout,
         "output_header": args.output_header,
         "output_quiet": args.output_quiet,
-        "error_no_exist": args.error_no_exist
+        "error_logfile_not_exist": args.error_logfile_not_exist
     }
     return config
 

--- a/check_log_ng.py
+++ b/check_log_ng.py
@@ -615,7 +615,7 @@ class LogChecker(object):
         if not os.path.exists(logfile):
             # if set error_logfile_not_exist, return UNKNOWN.
             if self.config['error_logfile_not_exist']:
-                self.message = "UNKNOWN: {0} is not found.".format(logfile)
+                self.message = "UNKNOWN: {0} is not exist.".format(logfile)
                 self.state = LogChecker.STATE_UNKNOWN
             return
 
@@ -703,7 +703,7 @@ class LogChecker(object):
 
         # if set error_logfile_not_exist, return UNKNOWN.
         if self.config['error_logfile_not_exist'] and len(logfile_list) == 0:
-            self.message = "UNKNOWN: {0} is not found.".format(logfile_pattern)
+            self.message = "UNKNOWN: {0} is not exist.".format(logfile_pattern)
             self.state = LogChecker.STATE_UNKNOWN
         return
 

--- a/test_check_log_ng.py
+++ b/test_check_log_ng.py
@@ -36,7 +36,7 @@ class LogCheckerTestCase(unittest.TestCase):
     MESSAGE_CRITICAL_ONE_WITH_HEADER = "CRITICAL: Critical Found 1 lines (HEADER): {0} at {1}"
     MESSAGE_UNKNOWN_LOCK_TIMEOUT = (
         "UNKNOWN: Lock timeout. Another process is running.")
-    MESSAGE_UNKNOWN_LOG_NOT_FOUND = "UNKNOWN: {0} is not found."
+    MESSAGE_UNKNOWN_LOG_NOT_EXIST = "UNKNOWN: {0} is not exist."
 
     # Class variablesex
     BASEDIR = None
@@ -612,7 +612,7 @@ class LogCheckerTestCase(unittest.TestCase):
         log.clear_state()
         log.check(logfile_pattern)
         self.assertEqual(log.get_state(), LogChecker.STATE_UNKNOWN)
-        self.assertEqual(log.get_message(), self.MESSAGE_UNKNOWN_LOG_NOT_FOUND.format(logfile_pattern))
+        self.assertEqual(log.get_message(), self.MESSAGE_UNKNOWN_LOG_NOT_EXIST.format(logfile_pattern))
 
         log = LogChecker(self.config)
         # --logfile option with multiple filenames(NOTEXISTFILE, NOTEXISTFILE)
@@ -620,7 +620,7 @@ class LogCheckerTestCase(unittest.TestCase):
         log.clear_state()
         log.check(logfile_pattern)
         self.assertEqual(log.get_state(), LogChecker.STATE_UNKNOWN)
-        self.assertEqual(log.get_message(), self.MESSAGE_UNKNOWN_LOG_NOT_FOUND.format(logfile_pattern))
+        self.assertEqual(log.get_message(), self.MESSAGE_UNKNOWN_LOG_NOT_EXIST.format(logfile_pattern))
 
         # --logfile option with multiple filenames(NOTEXISTFILE, EXISTFILE)
         log = LogChecker(self.config)

--- a/test_check_log_ng.py
+++ b/test_check_log_ng.py
@@ -99,7 +99,8 @@ class LogCheckerTestCase(unittest.TestCase):
             "scantime": 86400,
             "expiration": 691200,
             "cachetime": 0,
-            "lock_timeout": 3
+            "lock_timeout": 3,
+            "error_no_exist": False
         }
 
     def tearDown(self):
@@ -582,9 +583,29 @@ class LogCheckerTestCase(unittest.TestCase):
                 line1, self.logfile1, line2, self.logfile2))
 
     def test_logfile_NOT_FOUND(self):
-        """--logfile option
+        """--error-no-exist option
         """
+
+        # normal(Do not use error-no-exist option)
         self.config["pattern_list"] = ["ERROR"]
+        log = LogChecker(self.config)
+        # --logfile option with NOTEXISTFILE
+        logfile_pattern = "NOTEXISTFILE"
+        log.clear_state()
+        log.check(logfile_pattern)
+        self.assertEqual(log.get_state(), LogChecker.STATE_OK)
+        self.assertEqual(log.get_message(), self.MESSAGE_OK)
+
+        log = LogChecker(self.config)
+        # --logfile option with multiple filenames(NOTEXISTFILE, NOTEXISTFILE)
+        logfile_pattern = "{0} {1}".format("NOTEXISTFILE1", "NOTEXISTFILE2")
+        log.clear_state()
+        log.check(logfile_pattern)
+        self.assertEqual(log.get_state(), LogChecker.STATE_OK)
+        self.assertEqual(log.get_message(), self.MESSAGE_OK)
+
+        # use error-no-exist option
+        self.config["error_no_exist"] = ["True"]
         log = LogChecker(self.config)
         # --logfile option with NOTEXISTFILE
         logfile_pattern = "NOTEXISTFILE"

--- a/test_check_log_ng.py
+++ b/test_check_log_ng.py
@@ -583,10 +583,10 @@ class LogCheckerTestCase(unittest.TestCase):
                 line1, self.logfile1, line2, self.logfile2))
 
     def test_logfile_NOT_FOUND(self):
-        """--error-no-exist option
+        """--error-logfile-not-exist option
         """
 
-        # normal(Do not use error-no-exist option)
+        # normal(Do not use --error-logfile-not-exist option)
         self.config["pattern_list"] = ["ERROR"]
         log = LogChecker(self.config)
         # --logfile option with NOTEXISTFILE
@@ -604,7 +604,7 @@ class LogCheckerTestCase(unittest.TestCase):
         self.assertEqual(log.get_state(), LogChecker.STATE_OK)
         self.assertEqual(log.get_message(), self.MESSAGE_OK)
 
-        # use error-no-exist option
+        # use --error-logfile-not-exist option
         self.config["error_logfile_not_exist"] = ["True"]
         log = LogChecker(self.config)
         # --logfile option with NOTEXISTFILE
@@ -612,7 +612,8 @@ class LogCheckerTestCase(unittest.TestCase):
         log.clear_state()
         log.check(logfile_pattern)
         self.assertEqual(log.get_state(), LogChecker.STATE_UNKNOWN)
-        self.assertEqual(log.get_message(), self.MESSAGE_UNKNOWN_LOG_NOT_EXIST.format(logfile_pattern))
+        self.assertEqual(
+            log.get_message(), self.MESSAGE_UNKNOWN_LOG_NOT_EXIST.format(logfile_pattern))
 
         log = LogChecker(self.config)
         # --logfile option with multiple filenames(NOTEXISTFILE, NOTEXISTFILE)
@@ -620,7 +621,8 @@ class LogCheckerTestCase(unittest.TestCase):
         log.clear_state()
         log.check(logfile_pattern)
         self.assertEqual(log.get_state(), LogChecker.STATE_UNKNOWN)
-        self.assertEqual(log.get_message(), self.MESSAGE_UNKNOWN_LOG_NOT_EXIST.format(logfile_pattern))
+        self.assertEqual(
+            log.get_message(), self.MESSAGE_UNKNOWN_LOG_NOT_EXIST.format(logfile_pattern))
 
         # --logfile option with multiple filenames(NOTEXISTFILE, EXISTFILE)
         log = LogChecker(self.config)

--- a/test_check_log_ng.py
+++ b/test_check_log_ng.py
@@ -100,7 +100,7 @@ class LogCheckerTestCase(unittest.TestCase):
             "expiration": 691200,
             "cachetime": 0,
             "lock_timeout": 3,
-            "error_no_exist": False
+            "error_logfile_not_exist": False
         }
 
     def tearDown(self):
@@ -605,7 +605,7 @@ class LogCheckerTestCase(unittest.TestCase):
         self.assertEqual(log.get_message(), self.MESSAGE_OK)
 
         # use error-no-exist option
-        self.config["error_no_exist"] = ["True"]
+        self.config["error_logfile_not_exist"] = ["True"]
         log = LogChecker(self.config)
         # --logfile option with NOTEXISTFILE
         logfile_pattern = "NOTEXISTFILE"

--- a/test_check_log_ng.py
+++ b/test_check_log_ng.py
@@ -36,7 +36,7 @@ class LogCheckerTestCase(unittest.TestCase):
     MESSAGE_CRITICAL_ONE_WITH_HEADER = "CRITICAL: Critical Found 1 lines (HEADER): {0} at {1}"
     MESSAGE_UNKNOWN_LOCK_TIMEOUT = (
         "UNKNOWN: Lock timeout. Another process is running.")
-    MESSAGE_UNKNOWN_LOG_NOT_EXIST = "UNKNOWN: {0} is not exist."
+    MESSAGE_UNKNOWN_LOG_NOT_EXIST = "UNKNOWN: {0} does not exist."
 
     # Class variablesex
     BASEDIR = None

--- a/test_check_log_ng.py
+++ b/test_check_log_ng.py
@@ -36,7 +36,7 @@ class LogCheckerTestCase(unittest.TestCase):
     MESSAGE_CRITICAL_ONE_WITH_HEADER = "CRITICAL: Critical Found 1 lines (HEADER): {0} at {1}"
     MESSAGE_UNKNOWN_LOCK_TIMEOUT = (
         "UNKNOWN: Lock timeout. Another process is running.")
-    MESSAGE_UNKNOWN_LOG_NOT_FOUND = "UNKNOWN: Logfile is not found."
+    MESSAGE_UNKNOWN_LOG_NOT_FOUND = "UNKNOWN: {0} is not found."
 
     # Class variablesex
     BASEDIR = None
@@ -612,7 +612,7 @@ class LogCheckerTestCase(unittest.TestCase):
         log.clear_state()
         log.check(logfile_pattern)
         self.assertEqual(log.get_state(), LogChecker.STATE_UNKNOWN)
-        self.assertEqual(log.get_message(), self.MESSAGE_UNKNOWN_LOG_NOT_FOUND)
+        self.assertEqual(log.get_message(), self.MESSAGE_UNKNOWN_LOG_NOT_FOUND.format(logfile_pattern))
 
         log = LogChecker(self.config)
         # --logfile option with multiple filenames(NOTEXISTFILE, NOTEXISTFILE)
@@ -620,7 +620,7 @@ class LogCheckerTestCase(unittest.TestCase):
         log.clear_state()
         log.check(logfile_pattern)
         self.assertEqual(log.get_state(), LogChecker.STATE_UNKNOWN)
-        self.assertEqual(log.get_message(), self.MESSAGE_UNKNOWN_LOG_NOT_FOUND)
+        self.assertEqual(log.get_message(), self.MESSAGE_UNKNOWN_LOG_NOT_FOUND.format(logfile_pattern))
 
         # --logfile option with multiple filenames(NOTEXISTFILE, EXISTFILE)
         log = LogChecker(self.config)


### PR DESCRIPTION
If logfile is not found. This plugin return "OK - No matches found.".
I worry about if I wrong name in --logfile option. i will not notice it.

In check_log3.pl, if can not read logfile, return error.
https://github.com/pmcaulay/nagios-plugins/blob/master/check_log3.pl#L921-L934

** Proposal

If logfile is not found. Return code UNKNOWN, And message 「UNKNOWN: Logfile is not found.」

