### PR TITLE
Remove Python 2.6 from Travis CI's targets.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 #install:
 #  - pip install -r requirements.txt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.5"
   - "3.6"
-  - "3.7"
 #install:
 #  - pip install -r requirements.txt
 script:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/usr/local/bin/python3"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/local/bin/python3"
+}

--- a/test_check_log_ng.py
+++ b/test_check_log_ng.py
@@ -549,8 +549,9 @@ class LogCheckerTestCase(unittest.TestCase):
         # Dec  5 12:34:50 hostname test: ERROR
         line1 = self._make_line(self._get_timestamp(), "test", "ERROR")
         self._write_logfile(self.logfile1, line1)
+        time.sleep(1)
 
-        # Dec  5 12:34:50 hostname test: ERROR
+        # Dec  5 12:34:51 hostname test: ERROR
         line2 = self._make_line(self._get_timestamp(), "test", "ERROR")
         self._write_logfile(self.logfile2, line2)
         log.clear_state()
@@ -563,11 +564,12 @@ class LogCheckerTestCase(unittest.TestCase):
                 line1, self.logfile1, line2, self.logfile2))
 
         # --logfile option with multiple filenames
-        # Dec  5 12:34:50 hostname test: ERROR
+        # Dec  5 12:34:51 hostname test: ERROR
         line1 = self._make_line(self._get_timestamp(), "test", "ERROR")
         self._write_logfile(self.logfile1, line1)
+        time.sleep(1)
 
-        # Dec  5 12:34:50 hostname test: ERROR
+        # Dec  5 12:34:52 hostname test: ERROR
         line2 = self._make_line(self._get_timestamp(), "test", "ERROR")
         self._write_logfile(self.logfile2, line2)
         logfile_pattern = "{0} {1}".format(self.logfile1, self.logfile2)


### PR DESCRIPTION
Travis CI does not support Python 2.6 any more.
